### PR TITLE
プラグイン "Randam Generator" への新コマンド追加

### DIFF
--- a/lib/rgrb/plugin/random_generator/constants.rb
+++ b/lib/rgrb/plugin/random_generator/constants.rb
@@ -3,8 +3,12 @@
 module RGRB
   module Plugin
     module RandomGenerator
+      # 空白を表す正規表現
+      SPACES_RE = /[ 　]+/
       # 表名を表す正規表現
       TABLE_RE = /[-_0-9A-Za-z]+/
+      # 表のリストを表す正規表現
+      TABLES_RE = /(#{TABLE_RE}(?: +#{TABLE_RE})*)/o
       # 変数を表す正規表現
       VARIABLE_RE = /%%(#{TABLE_RE})%%/o
     end

--- a/lib/rgrb/plugin/random_generator/generator.rb
+++ b/lib/rgrb/plugin/random_generator/generator.rb
@@ -42,6 +42,16 @@ module RGRB
           replace_var_with_value(get_value_from(table), table)
         end
 
+        # 指定した表の Description を返す
+        # @param [String] table 表名
+        # @return [String]
+        # @raise [TableNotFound] 表が見つからなかった場合
+        def info(table_name)
+          fail(TableNotFound, table_name) unless @table[table_name]
+
+          @table[table_name].description
+        end
+
         # 表から値を取得して返す
         # @param [String] table_name 表名
         # @return [String]

--- a/lib/rgrb/plugin/random_generator/generator.rb
+++ b/lib/rgrb/plugin/random_generator/generator.rb
@@ -42,14 +42,30 @@ module RGRB
           replace_var_with_value(get_value_from(table), table)
         end
 
-        # 指定した表の Description を返す
+        def desc(table_name)
+          fail(TableNotFound, table_name) unless @table[table_name]
+
+          @table[table_name].description
+        end
+
+        # 指定した表の説明を返す
         # @param [String] table 表名
         # @return [String]
         # @raise [TableNotFound] 表が見つからなかった場合
         def info(table_name)
           fail(TableNotFound, table_name) unless @table[table_name]
 
-          @table[table_name].description
+          mes = "#{table_name}は、" \
+            "#{@table[table_name].jadded}に" \
+            "#{@table[table_name].author}さんによって追加されましたの。"
+          unless @table[table_name].jmodified == nil 
+            mes = mes \
+              + "最後に更新されたのは" \
+                "#{@table[table_name].jmodified}" \
+                "ですわ。"
+          end
+
+          mes + "#{@table[table_name].description}"
         end
 
         # 表から値を取得して返す

--- a/lib/rgrb/plugin/random_generator/irc_adapter.rb
+++ b/lib/rgrb/plugin/random_generator/irc_adapter.rb
@@ -18,6 +18,7 @@ module RGRB
 
         set(plugin_name: 'RandomGenerator')
         match(/rg[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :rg)
+        match(/rg-desc[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :desc)
         match(/rg-info[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :info)
 
         def initialize(*args)
@@ -47,8 +48,24 @@ module RGRB
           end
         end
 
+        def desc(m, tables_str)
+          header = "rg-desc[#{m.user.nick}"
+
+          tables_str.split(' ').each do |table|
+            body =
+              begin
+                "<#{table}>: #{@generator.desc(table)} ☆"
+              rescue TableNotFound => not_found
+                ": 「#{not_found.table}」なんて表は見つからないのですわっ。"
+              end
+            m.target.send(header + body, true)
+
+            sleep(1)
+          end
+        end
+
         def info(m, tables_str)
-          header = "rg[#{m.user.nick}]"
+          header = "rg-info[#{m.user.nick}]"
 
           tables_str.split(' ').each do |table|
             body =

--- a/lib/rgrb/plugin/random_generator/irc_adapter.rb
+++ b/lib/rgrb/plugin/random_generator/irc_adapter.rb
@@ -17,9 +17,9 @@ module RGRB
         include ConfigurableAdapter
 
         set(plugin_name: 'RandomGenerator')
-        match(/rg[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :rg)
-        match(/rg-desc[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :desc)
-        match(/rg-info[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :info)
+        match(/rg#{SPACES_RE}#{TABLES_RE}/o, method: :rg)
+        match(/rg-desc#{SPACES_RE}#{TABLES_RE}/o, method: :desc)
+        match(/rg-info#{SPACES_RE}#{TABLES_RE}/o, method: :info)
 
         def initialize(*args)
           super
@@ -49,12 +49,12 @@ module RGRB
         end
 
         def desc(m, tables_str)
-          header = "rg-desc[#{m.user.nick}"
+          header = "rg-desc"
 
           tables_str.split(' ').each do |table|
             body =
               begin
-                "<#{table}>: #{@generator.desc(table)} ☆"
+                "<#{table}>: #{@generator.desc(table)} "
               rescue TableNotFound => not_found
                 ": 「#{not_found.table}」なんて表は見つからないのですわっ。"
               end
@@ -65,12 +65,12 @@ module RGRB
         end
 
         def info(m, tables_str)
-          header = "rg-info[#{m.user.nick}]"
+          header = "rg-info"
 
           tables_str.split(' ').each do |table|
             body =
               begin
-                "<#{table}>: #{@generator.info(table)} ☆"
+                "<#{table}>: #{@generator.info(table)} "
               rescue TableNotFound => not_found
                 ": 「#{not_found.table}」なんて表は見つからないのですわっ。"
               end

--- a/lib/rgrb/plugin/random_generator/irc_adapter.rb
+++ b/lib/rgrb/plugin/random_generator/irc_adapter.rb
@@ -18,6 +18,7 @@ module RGRB
 
         set(plugin_name: 'RandomGenerator')
         match(/rg[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :rg)
+        match(/rg-info[ 　]+(#{TABLE_RE}(?: +#{TABLE_RE})*)/o, method: :info)
 
         def initialize(*args)
           super
@@ -39,6 +40,22 @@ module RGRB
               rescue CircularReference => circular_reference
                 ": 表「#{circular_reference.table}」で循環参照が起こりました。" \
                   '#cre でご報告ください。'
+              end
+            m.target.send(header + body, true)
+
+            sleep(1)
+          end
+        end
+
+        def info(m, tables_str)
+          header = "rg[#{m.user.nick}]"
+
+          tables_str.split(' ').each do |table|
+            body =
+              begin
+                "<#{table}>: #{@generator.info(table)} ☆"
+              rescue TableNotFound => not_found
+                ": 「#{not_found.table}」なんて表は見つからないのですわっ。"
               end
             m.target.send(header + body, true)
 

--- a/lib/rgrb/plugin/random_generator/table.rb
+++ b/lib/rgrb/plugin/random_generator/table.rb
@@ -107,6 +107,12 @@ module RGRB
         def sample(random: Random::DEFAULT)
           @values.sample(random: random)
         end
+
+        # 表の説明を返す
+        # @return [String]
+        def desctiption()
+          @description
+        end
       end
     end
   end

--- a/lib/rgrb/plugin/random_generator/table.rb
+++ b/lib/rgrb/plugin/random_generator/table.rb
@@ -113,6 +113,18 @@ module RGRB
         def desctiption()
           @description
         end
+
+        def author()
+          @author
+        end
+
+        def jadded()
+          @added.strftime("%Y年%m月%d日")
+        end
+
+        def jmodified()
+          @modified.strftime("%Y年%m月%d日")
+        end
       end
     end
   end


### PR DESCRIPTION
#8 
指定した表の説明を返すコマンドを2つ追加しました。

## .rg-desc

指定した表のメタ情報"Description"を返します。
```
<nick> .rg-desc SVOC  
<RGRB> rg-desc<SVOC>: 形容詞・主語・目的語・述語を並べ、謎の短文を作ります。
```

## .rg-info

指定した表のメタ情報から、作者(author)・作成日(added)・説明(Description)と、あれば更新日(modified)を返します。
```
<nick> .rg-info SVOC
<RGRB> rg-info<SVOC>: SVOCは、2014年12月15日にsfさんによって追加されましたの。最後に更新されたのは2014年12月20日ですわ。形容詞・主語・目的語・述語を並べ、謎の短文を作ります。
```

## その他

上記2つのコマンドを作成するうえで、コマンド定義部分の正規表現が何回も出てきていたため、改めて定数として定義し直しました。