### PR TITLE
テストの改良

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 汎用 IRC ボット RGRB
 ====================
 
-[![Build Status](https://travis-ci.org/cre-ne-jp/rgrb.svg?branch=master)](https://travis-ci.org/cre-ne-jp/rgrb) [![Coverage Status](https://coveralls.io/repos/cre-ne-jp/rgrb/badge.svg?branch=master)](https://coveralls.io/r/cre-ne-jp/rgrb?branch=master)
+[![Build Status](https://travis-ci.org/cre-ne-jp/rgrb.svg?branch=master)](https://travis-ci.org/cre-ne-jp/rgrb)
+[![Coverage Status](https://coveralls.io/repos/cre-ne-jp/rgrb/badge.svg?branch=master&service=github)](https://coveralls.io/github/cre-ne-jp/rgrb?branch=master)
 
 RGRB は Ruby で実装されている汎用 IRC ボットです。プラグイン方式により柔軟な拡張が可能です。
 

--- a/spec/rgrb/plugin/online_session_search/generator_spec.rb
+++ b/spec/rgrb/plugin/online_session_search/generator_spec.rb
@@ -92,7 +92,8 @@ describe RGRB::Plugin::OnlineSessionSearch::Generator do
       end
 
       it do
-        expect { generator.send(:session_data_from, url) }.to raise_error
+        expect { generator.send(:session_data_from, url) }.
+          to raise_error(StandardError)
       end
     end
 

--- a/spec/rgrb/plugin/random_generator/generator_spec.rb
+++ b/spec/rgrb/plugin/random_generator/generator_spec.rb
@@ -104,33 +104,13 @@ describe RGRB::Plugin::RandomGenerator::Generator do
     end
 
     context 'hiraganarand' do
-      # 要素数 10 の表から 100000 回取得したときに偏りが
-      # ないことをカイ二乗検定で確かめる
-      it '各値が偏りなく出る' do
+      it '100 回取り出したとき、値がすべて同じではない' do
         table = 'hiraganarand'
-        data = generator.
-          instance_variable_get(:@table)['hiraganarand'].
-          instance_variable_get(:@values)
-        freq = {}
-
-        # 頻度を入れるハッシュを初期化する
-        data.each do |value|
-          freq[value] = 0
+        results = Array.new(100) do
+          generator.send(:get_value_from, table)
         end
 
-        n_gets = 100_000
-        n_gets.times do
-          freq[generator.send(:get_value_from, table)] += 1
-        end
-
-        # カイ二乗値を求める
-        expected_count = n_gets.to_f / data.length
-        chi2 = freq.
-          each_value.
-          map { |count| (count - expected_count)**2 / expected_count }.
-          reduce(0, :+)
-
-        expect(chi2).to be <= 23.5894 # 自由度 9、有意水準 0.5%
+        expect(results.uniq.length).to be > 1
       end
     end
   end

--- a/spec/rgrb/plugins_loader_spec.rb
+++ b/spec/rgrb/plugins_loader_spec.rb
@@ -66,7 +66,7 @@ describe RGRB::PluginsLoader do
         context 'skip_on_load_error = false' do
           it do
             expect { wrong_plugins_loader.load_each('Generator') }.
-              to raise_error
+              to raise_error(LoadError)
           end
         end
 


### PR DESCRIPTION
* .rg の偏りテストで必要以上に偏りを検知しないようにする。
* RSpec の仕様変更に伴い、`raise_error` で発生するエラーを明示する。