### PR TITLE
ServerConnectionReport で、接続・切断通知をメールでも行なえるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'twitter', '~> 5.11'
 gem 'lumberjack', '~> 1.0'
 gem 'sysexits', '~> 1.2'
 gem 'd1lcs', '~> 0.5.1'
+gem 'mail', '~> 2.6.3'
 
 group :development, :test do
   gem 'pry', '~> 0.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     lumberjack (1.0.9)
+    mail (2.6.3)
+      mime-types (>= 1.16, < 3)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
@@ -127,6 +129,7 @@ DEPENDENCIES
   coveralls
   d1lcs (~> 0.5.1)
   lumberjack (~> 1.0)
+  mail (~> 2.6.3)
   pry (~> 0.10)
   rake (~> 10.4)
   rspec (~> 3.1)

--- a/config/server_connection_report/charybdis.yaml
+++ b/config/server_connection_report/charybdis.yaml
@@ -2,7 +2,7 @@
 ServerConnectionReport::Charybdis:
   # NOTICE を行うチャンネルの一覧
   ChannelsToSend:
-    - ''
+    - '#irc_test'
 
   # 反応すべきメッセージの送信者の一覧
   AllowedSenders:
@@ -13,3 +13,20 @@ ServerConnectionReport::Charybdis:
     - t-net.xyz
     - irc.sougetu.net
     - irc.kazagakure.net
+
+  # 送信するメールのテンプレートファイルID
+  # data/server_connection_report/ に保存したテキストファイル(.txt)の
+  # ファイル名部を指定する
+  MessageTemplate: 'cre'
+
+  # 送信設定
+  Mail:
+    To: 
+      - 'koi-chan@mail.kazagakure.net'
+    SMTP:
+      address: 'localhost'
+      port: 25
+      domain: 'vm11.kazagakure.net'
+      authentication: false
+      ssl: false
+      enable_starttls_auto: false

--- a/config/server_connection_report/test.yaml
+++ b/config/server_connection_report/test.yaml
@@ -1,0 +1,26 @@
+# Test 用サーバーリレー監視プラグインの設定
+ServerConnectionReport::Test:
+  # NOTICE を行うチャンネルの一覧
+  ChannelsToSend:
+    - '#irc_test'
+
+  # 反応すべきメッセージの送信者の一覧
+  AllowedSenders:
+    - irc.cre.jp
+    - irc.r-roman.net
+    - services.cre.jp
+    - irc.egotex.net
+    - t-net.xyz
+    - irc.sougetu.net
+    - irc.kazagakure.net
+
+  # 送信するメールのテンプレートファイルID
+  # data/server_connection_report/ に保存したテキストファイル(.txt)の
+  # ファイル名部を指定する
+  MessageTemplate: 'cre'
+
+  # 送信設定
+  Mail:
+    To: 
+      - 'koi-chan@mail.kazagakure.net'
+#    Smtp:

--- a/config/server_connection_report/test.yaml
+++ b/config/server_connection_report/test.yaml
@@ -23,4 +23,10 @@ ServerConnectionReport::Test:
   Mail:
     To: 
       - 'koi-chan@mail.kazagakure.net'
-#    Smtp:
+    SMTP:
+      address: 'localhost'
+      port: 25
+      domain: 'vm11.kazagakure.net'
+      authentication: false
+      ssl: false
+      enable_starttls_auto: false

--- a/data/server_connection_report/cre.txt
+++ b/data/server_connection_report/cre.txt
@@ -1,5 +1,4 @@
-IRC サーバー接続状態通知 (%{server})
+IRC サーバ%{status2}通知 (%{server})
 
-「irc.cre.jp 系IRCサーバ群」の公式ボット、%{nick} よりお知らせします。
-%{time}、IRC サーバー "%{server}" がネットワーク%{status}ました。
+"%{server}" がネットワーク%{status1}ました。
 

--- a/data/server_connection_report/cre.txt
+++ b/data/server_connection_report/cre.txt
@@ -1,0 +1,5 @@
+IRC サーバー接続状態通知 (%{server})
+
+「irc.cre.jp 系IRCサーバ群」の公式ボット、%{nick} よりお知らせします。
+%{time}、IRC サーバー "%{server}" がネットワーク%{status}ました。
+

--- a/doc/plugins/server_connection_report.md
+++ b/doc/plugins/server_connection_report.md
@@ -59,6 +59,32 @@ ServerConnectionReport::Charybdis:
     - '#cre'
 ```
 
+さらに、charybdis 用のプラグインはメールでの通知にも対応しています。  
+設定ファイルに以下を追記して、メール関係の設定を行います。
+
+```yaml
+  # 送信するメールのテンプレートファイルID
+  # data/server_connection_report/ に保存したテキストファイル(.txt)の
+  # ファイル名部を指定する
+  MessageTemplate: 'template'
+
+  # 送信設定
+  Mail:
+    To: 
+      - 'irc-operator@example.com'
+    SMTP:
+      address: 'localhost'
+      port: 25
+      domain: 'mail.example.com'
+      authentication: false
+      ssl: false
+      enable_starttls_auto: false
+```
+
+#### MessageTemplate に指定するファイルについての注記
+
+_MessageTemplate_ に指定するファイルは、1行目がメールの件名(Subject)として利用され、2行目は何が書かれていても無視します。
+
 ### Atheme-Services
 
 Atheme-Services を利用している環境であれば、IRC デーモンの種類を問わずこのプラグインでサーバーの接続状態を検知できます。初期設定では「#services」チャンネルに情報が出力されます。RGRB がこのチャンネルに参加している必要があります。

--- a/lib/rgrb/plugin/server_connection_report/atheme_services/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/atheme_services/irc_adapter.rb
@@ -51,6 +51,7 @@ module RGRB
           def joined(m, server)
             if m.channel == SERVER_MESSAGE_CHANNEL
               log_incoming(m)
+              sleep 1
               notice_on_each_channel(@generator.joined(server))
             end
           end

--- a/lib/rgrb/plugin/server_connection_report/charybdis/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/charybdis/irc_adapter.rb
@@ -62,6 +62,7 @@ module RGRB
           def joined(m, server)
             if m.server
               log_incoming(m)
+              sleep 1
               notice_on_each_channel(@generator.joined(server))
             end
           end

--- a/lib/rgrb/plugin/server_connection_report/charybdis/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/charybdis/irc_adapter.rb
@@ -62,7 +62,7 @@ module RGRB
           # @param [String] comment コメント
           # @return [void]
           def disconnected(m, server, comment)
-            _connected(m, server, comment)
+            _disconnected(m, server, comment)
           end
 
           # サーバーへの接続が完了したとき、情報を集める

--- a/lib/rgrb/plugin/server_connection_report/common_disposal.rb
+++ b/lib/rgrb/plugin/server_connection_report/common_disposal.rb
@@ -1,0 +1,78 @@
+# vim: fileencoding=utf-8
+
+require 'cinch'
+
+require 'rgrb/plugin/util/notice_on_each_channel'
+require 'rgrb/plugin/util/logging'
+require 'rgrb/plugin/server_connection_report/constants'
+require 'rgrb/plugin/server_connection_report/generator'
+require 'rgrb/plugin/server_connection_report/common_disposal'
+
+module RGRB
+  module Plugin
+    module ServerConnectionReport
+      # サーバリレー監視プラグイン アダプター共通モジュール
+      #
+      # サーバの接続状態が変化したとき、各デーモンで共通な処理を処理する。
+      module CommonDisposal
+        include Cinch::Plugin
+        include Util::NoticeOnEachChannel
+        include Util::Logging
+
+        # メッセージを送信するチャンネルのリスト
+        attr_reader :channels_to_send
+
+        set(plugin_name: 'ServerConnectionReport::CommonDisposal')
+        self.prefix = ''
+
+        def initialize(*)
+          super
+          config_data = config[:plugin]
+          @channels_to_send = config_data['ChannelsToSend'] || []
+
+          @generator = Generator.new
+          @generator.root_path = config[:root_path]
+          @generator.configure(config[:plugin])
+        end
+
+        # サーバ接続メッセージを NOTICE する
+        # @param [Cinch::Message] m メッセージ
+        # @param [String] server サーバ
+        # @return [void]
+        def _joined(m, server)
+          if m.server
+            log_incoming(m)
+            sleep 1
+            notice_on_each_channel(@generator.joined(server, m.time))
+          end
+        end
+
+        # サーバ切断メッセージを NOTICE する
+        # @param [Cinch::Message] m メッセージ
+        # @param [String] server サーバ
+        # @param [String] comment コメント
+        # @return [void]
+        def _disconnected(m, server, comment)
+          if m.server
+            log_incoming(m)
+            notice_on_each_channel(
+              @generator.disconnected(server, m.time, comment)
+            )
+          end
+        end
+
+        # サーバーへの接続が完了したとき、情報を集める
+        # @param [Cinch::Message] m メッセージ
+        # @return [void]
+        def _connected(m)
+          sleep 1
+          @generator.connection_datas = {
+            host: bot.host,
+            nick: bot.nick,
+            network: bot.irc.isupport['NETWORK']
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/rgrb/plugin/server_connection_report/generator.rb
+++ b/lib/rgrb/plugin/server_connection_report/generator.rb
@@ -14,7 +14,11 @@ module RGRB
         # @param [Hash] config_data 設定データのハッシュ
         # @return [self]
         def configure(config_data)
-          @mail = MailSender.new(config_data['mail'] || {})
+          super
+
+          @mail = MailSender.new(config_data['Mail'] || {})
+          @mail.load_message_template("#{@data_path}/#{config_data['MessageTemplate']}.txt")
+
           self
         end
 

--- a/lib/rgrb/plugin/server_connection_report/generator.rb
+++ b/lib/rgrb/plugin/server_connection_report/generator.rb
@@ -1,18 +1,35 @@
 # vim: fileencoding=utf-8
 
+require 'mail'
+require 'pp'
+
 module RGRB
   module Plugin
     # サーバーリレー監視プラグイン
     module ServerConnectionReport
       # ServerConnectionReport の出力テキスト生成器
       class Generator
+        # 設定データを解釈してプラグインの設定を行う
+        # @param [Hash] config_data 設定データのハッシュ
+        # @return [self]
+        def configure(config_data)
+#          mailconf = config_data['mail']
+
+#          Mail.defaults do
+#            from    'RGRB (%{nick}) <rgrb-%{nick}@%{server}>'
+#            to      mailconf['to']
+#            subject 'IRC Server %{server} Connection Report'
+#            delivery_method(:smtp, mailconf['smtp'])
+#          end
+        end
+
         # サーバがネットワークに参加した際のメッセージを返す
         # @param [String] server サーバ名
         # @param [String] message メッセージ
         # @return [String]
         def joined(server, message = nil)
           common_part = "!! #{server} がネットワークに参加しました"
-          message ? "#{common_part} (#{message})" : common_part
+          sendmail message ? "#{common_part} (#{message})" : common_part
         end
 
         # サーバがネットワークから切断された際のメッセージを返す
@@ -21,7 +38,23 @@ module RGRB
         # @return [String]
         def disconnected(server, message = nil)
           common_part = "!! #{server} がネットワークから切断されました"
-          message ? "#{common_part} (#{message})" : common_part
+          sendmail message ? "#{common_part} (#{message})" : common_part
+        end
+
+        # メールを送信する
+        # @param [String] message 送信内容
+        # @return [String]
+        def sendmail(message)
+          sendmes = <<-__EOT__
+IRC サーバ　接続状態通知
+: #{Date.now}
+
+          __EOT__
+#          mail = Mail.new
+#          mail.body = sendmes % {nick: m.}
+#          mail.deliver
+
+          message
         end
       end
     end

--- a/lib/rgrb/plugin/server_connection_report/generator.rb
+++ b/lib/rgrb/plugin/server_connection_report/generator.rb
@@ -27,7 +27,7 @@ module RGRB
         # @param [DateTime] time 接続時間
         # @param [String] message メッセージ
         # @return [String]
-        def joined(server, time, message = nil)
+        def joined(server, time = nil, message = nil)
           common_part = "!! #{server} がネットワークに参加しました"
           @mail.send(server, :joined, time, message)
           message ? "#{common_part} (#{message})" : common_part
@@ -38,7 +38,7 @@ module RGRB
         # @param [DateTime] time 切断時間
         # @param [String] message メッセージ
         # @return [String]
-        def disconnected(server, time, message = nil)
+        def disconnected(server, time = nil, message = nil)
           common_part = "!! #{server} がネットワークから切断されました"
           @mail.send(server, :disconnected, time, message)
           message ? "#{common_part} (#{message})" : common_part

--- a/lib/rgrb/plugin/server_connection_report/mail_sender.rb
+++ b/lib/rgrb/plugin/server_connection_report/mail_sender.rb
@@ -1,6 +1,7 @@
 # vim: fileencoding=utf-8
 
 require 'mail'
+require 'lumberjack'
 
 module RGRB
   module Plugin
@@ -15,16 +16,14 @@ module RGRB
         def initialize(config)
           if(config['smtp'])
             Mail.defaults do
-              delivery_method(:smtp, config['smtp'])
+              delivery_method(:smtp, config['SMTP'])
             end
           end
-          @to = config['to'] || 'root@localhost'
-          if(config['address'])
-            @address = config['address']
-          else
-            # error
-            @address = 'return@example.com'
-          end
+          @to = config['To'] || 'root@localhost'
+
+          @logger = Lumberjack::Logger.new(
+            $stdout, progname: self.class.to_s
+          )
         end
 
         # 接続設定を保存する
@@ -32,6 +31,36 @@ module RGRB
         # @param [String] :nick ボットのニックネーム
         # @param [String] :network ネットワーク名
         attr_writer :connection_datas
+
+        # メールのテンプレートを読み込む
+        # @param [String] path テンプレートファイル(text/plain)のパス
+        # @return [void]
+        def load_message_template(path)
+          begin
+            template = File.read(path, encoding: 'UTF-8')
+            @logger.warn("メールテンプレート #{path} の読み込みが完了しました")
+          rescue => e
+            @logger.error("メールテンプレート #{path} の読み込みに失敗しました")
+            @logger.error(e)
+          end
+
+          line_flag = :first
+          template.each_line do |line|
+            case line_flag
+            when :first
+              # 1行目は件名
+              line_flag = :second
+              @subject = line.chomp
+            when :second
+              # 2行目は破棄
+              line_flag = :body
+              @body = ''
+            when :body
+              # 3行目以降は本文
+              @body << line
+            end
+          end
+        end
 
         # メールを送信する
         # @param [String] server 対象のサーバー
@@ -41,8 +70,10 @@ module RGRB
         # @return [String]
         def send(server, status, time, message)
           data_parts = @connection_datas.clone
+          data_parts[:time] = time.strftime('%Y年%m月%d日 %H:%M:%S')
           data_parts[:server] = server
           data_parts[:message] = message
+          data_parts[:rgrb_version] = RGRB::VERSION
           data_parts[:status] = case status
           when :joined
             'に参加し'
@@ -51,33 +82,16 @@ module RGRB
           end
 
           mail = Mail.new
+          mail['charset'] = 'utf-8'
+          mail['to']      = @to
           {
-            charset:  'utf-8',
             from:     '%{nick} on %{network} <rgrb-%{nick}@%{host}>',
-            to:       @to,
-            subject:  'IRC Server "%{server}" Connection Report',
-            body:     <<-__EOT__
-IRC サーバー接続状態通知
-
-%{network} に接続されている IRC ボット、%{nick} よりお知らせします。
-#{time.strftime('%Y年%m月%d日 %H:%M:%S')}、IRC サーバー %{server} がネットワーク%{status}ました。
-
-IRC サーバーより送信されたメッセージ
-%{message}
-ここまで============================
-
-
-このメールは汎用 IRC ボット "RGRB" に組み込まれたプラグイン "ServerConnectionReport" により送信されました。
-RGRB ver#{RGRB::VERSION}
-Development: https://github.com/cre-ne-jp/rgrb
-
-心当たりがない場合は、お手数をですが以下までご連絡いただきますよう、よろしくお願い致します。
-IRC ボット "%{nick}" 運営者連絡先: #{@address}
-
-            __EOT__
+            subject:  @subject,
+            body:     @body
           }.each do |key, value|
             mail[key] = value % data_parts
           end
+puts "Subject: #{mail.subject}\n"
 puts mail.body
 puts mail.to_s
         end

--- a/lib/rgrb/plugin/server_connection_report/mail_sender.rb
+++ b/lib/rgrb/plugin/server_connection_report/mail_sender.rb
@@ -74,11 +74,11 @@ module RGRB
           data_parts[:server] = server
           data_parts[:message] = message
           data_parts[:rgrb_version] = RGRB::VERSION
-          data_parts[:status] = case status
+          data_parts[:status1], data_parts[:status2] = case status
           when :joined
-            'に参加し'
+            ['に参加し', '接続']
           when :disconnected
-            'から切断され'
+            ['から切断され', '切断']
           end
 
           mail = Mail.new

--- a/lib/rgrb/plugin/server_connection_report/mail_sender.rb
+++ b/lib/rgrb/plugin/server_connection_report/mail_sender.rb
@@ -1,0 +1,87 @@
+# vim: fileencoding=utf-8
+
+require 'mail'
+
+module RGRB
+  module Plugin
+    # サーバーリレー監視プラグイン
+    module ServerConnectionReport
+      # メール送信を司るクラス
+      class MailSender
+        # 送信データを初期化する
+        # @param [Hash] config
+        # @option [String] to 送信先
+        # @option [Hash] smtp 送信に利用するSMTPサーバーの設定
+        def initialize(config)
+          if(config['smtp'])
+            Mail.defaults do
+              delivery_method(:smtp, config['smtp'])
+            end
+          end
+          @to = config['to'] || 'root@localhost'
+          if(config['address'])
+            @address = config['address']
+          else
+            # error
+            @address = 'return@example.com'
+          end
+        end
+
+        # 接続設定を保存する
+        # @param [String] :host 接続サーバーのホスト名
+        # @param [String] :nick ボットのニックネーム
+        # @param [String] :network ネットワーク名
+        attr_writer :connection_datas
+
+        # メールを送信する
+        # @param [String] server 対象のサーバー
+        # @param [Symbol] status サーバーのステータス
+        # @param [DateTime] time 接続・切断時間
+        # @param [String] message 補足メッセージ
+        # @return [String]
+        def send(server, status, time, message)
+          data_parts = @connection_datas.clone
+          data_parts[:server] = server
+          data_parts[:message] = message
+          data_parts[:status] = case status
+          when :joined
+            'に参加し'
+          when :disconnected
+            'から切断され'
+          end
+
+          mail = Mail.new
+          {
+            charset:  'utf-8',
+            from:     '%{nick} on %{network} <rgrb-%{nick}@%{host}>',
+            to:       @to,
+            subject:  'IRC Server "%{server}" Connection Report',
+            body:     <<-__EOT__
+IRC サーバー接続状態通知
+
+%{network} に接続されている IRC ボット、%{nick} よりお知らせします。
+#{time.strftime('%Y年%m月%d日 %H:%M:%S')}、IRC サーバー %{server} がネットワーク%{status}ました。
+
+IRC サーバーより送信されたメッセージ
+%{message}
+ここまで============================
+
+
+このメールは汎用 IRC ボット "RGRB" に組み込まれたプラグイン "ServerConnectionReport" により送信されました。
+RGRB ver#{RGRB::VERSION}
+Development: https://github.com/cre-ne-jp/rgrb
+
+心当たりがない場合は、お手数をですが以下までご連絡いただきますよう、よろしくお願い致します。
+IRC ボット "%{nick}" 運営者連絡先: #{@address}
+
+            __EOT__
+          }.each do |key, value|
+            mail[key] = value % data_parts
+          end
+puts mail.body
+puts mail.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/rgrb/plugin/server_connection_report/mail_sender.rb
+++ b/lib/rgrb/plugin/server_connection_report/mail_sender.rb
@@ -14,10 +14,11 @@ module RGRB
         # @option [String] to 送信先
         # @option [Hash] smtp 送信に利用するSMTPサーバーの設定
         def initialize(config)
-          if(config['smtp'])
-            Mail.defaults do
-              delivery_method(:smtp, config['SMTP'])
-            end
+          if(config['SMTP'])
+            @mail_config = symbolize_keys(config['SMTP'])
+              .delete_if do |key, value|
+                value == 'nil'
+              end
           end
           @to = config['To'] || 'root@localhost'
 
@@ -82,6 +83,7 @@ module RGRB
           end
 
           mail = Mail.new
+          mail.delivery_method(:smtp, @mail_config)
           mail['charset'] = 'utf-8'
           mail['to']      = @to
           {
@@ -94,7 +96,15 @@ module RGRB
 puts "Subject: #{mail.subject}\n"
 puts mail.body
 puts mail.to_s
+          mail.deliver
         end
+
+        def symbolize_keys(hash)
+          hash.map { |key, value|
+            [key.to_sym, value]
+          }.to_h
+        end
+        private :symbolize_keys
       end
     end
   end

--- a/lib/rgrb/plugin/server_connection_report/ngircd/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/ngircd/irc_adapter.rb
@@ -51,6 +51,7 @@ module RGRB
           def joined(m, server)
             if m.channel == SERVER_MESSAGE_CHANNEL
               log_incoming(m)
+              sleep 1
               notice_on_each_channel(@generator.joined(server))
             end
           end

--- a/lib/rgrb/plugin/server_connection_report/test/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/test/irc_adapter.rb
@@ -7,6 +7,7 @@ require 'rgrb/plugin/util/notice_on_each_channel'
 require 'rgrb/plugin/util/logging'
 require 'rgrb/plugin/server_connection_report/constants'
 require 'rgrb/plugin/server_connection_report/generator'
+require 'rgrb/plugin/server_connection_report/common_disposal'
 
 module RGRB
   module Plugin
@@ -25,9 +26,7 @@ module RGRB
           include Cinch::Plugin
           include Util::NoticeOnEachChannel
           include Util::Logging
-
-          # メッセージを送信するチャンネルのリスト
-          attr_reader :channels_to_send
+          include CommonDisposal
 
           # サーバーがネットワークに参加したときのメッセージを表す正規表現
           NETJOIN_RE =
@@ -86,16 +85,8 @@ module RGRB
             end
           end
 
-          # サーバーへの接続が完了したとき、情報を集める
-          # @param [Cinch::Message] m メッセージ
-          # @return [void]
           def connected(m)
-            sleep 1
-            @generator.connection_datas = {
-              host: bot.host,
-              nick: bot.nick,
-              network: bot.irc.isupport['NETWORK']
-            }
+            _connected(m)
           end
         end
       end

--- a/lib/rgrb/plugin/server_connection_report/test/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/test/irc_adapter.rb
@@ -1,0 +1,104 @@
+# vim: fileencoding=utf-8
+
+require 'cinch'
+require 'pp'
+
+require 'rgrb/plugin/util/notice_on_each_channel'
+require 'rgrb/plugin/util/logging'
+require 'rgrb/plugin/server_connection_report/constants'
+require 'rgrb/plugin/server_connection_report/generator'
+
+module RGRB
+  module Plugin
+    module ServerConnectionReport
+      # Test 用サーバリレー監視プラグイン。
+      #
+      # サーバの接続状態が変化したときに Oper ユーザーに送信される PRIVMSG
+      # を解析する。
+      # したがって、基本的にボットが Oper であることが必要である。
+      #
+      # 送信元を指定するオプション AllowedSenders にサーバアドレスを追加
+      # し、受信するメッセージを絞る。
+      module Test
+        # ServerConnectionReport::Test の IRC アダプター
+        class IrcAdapter
+          include Cinch::Plugin
+          include Util::NoticeOnEachChannel
+          include Util::Logging
+
+          # メッセージを送信するチャンネルのリスト
+          attr_reader :channels_to_send
+
+          # サーバーがネットワークに参加したときのメッセージを表す正規表現
+          NETJOIN_RE =
+            /jointest #{HOSTNAME_RE} <-> (#{HOSTNAME_RE})/o
+          # サーバーがネットワークから切断されたときのメッセージを表す
+          # 正規表現
+          NETSPLIT_RE =
+            /splittest #{HOSTNAME_RE} <-> (#{HOSTNAME_RE}) \(.+?\) \((.+)\)/o
+
+          set(plugin_name: 'ServerConnectionReport::Test')
+          self.prefix = ''
+
+          # サーバーがネットワークに参加したときのメッセージを表す正規表現
+          match(NETJOIN_RE, method: :joined)
+          # サーバーがネットワークから切断されたときのメッセージを表す
+          # 正規表現
+          match(NETSPLIT_RE, method: :disconnected)
+          # サーバーへの接続が完了したときに情報を集める
+          listen_to(:'002', method: :connected)
+
+          def initialize(*)
+            super
+
+            config_data = config[:plugin]
+            @channels_to_send = config_data['ChannelsToSend'] || []
+            @testchannel = config_data['TestChannel'] || '#irc_test'
+
+            @generator = Generator.new
+            @generator.root_path = config[:root_path]
+            @generator.configure(config[:plugin])
+          end
+
+          # サーバ接続メッセージを NOTICE する
+          # @param [Cinch::Message] m メッセージ
+          # @param [String] server サーバ
+          # @return [void]
+          def joined(m, server)
+            if m.channel == @testchannel
+              log_incoming(m)
+              sleep 1
+              notice_on_each_channel(@generator.joined(server, m.time))
+            end
+          end
+
+          # サーバ切断メッセージを NOTICE する
+          # @param [Cinch::Message] m メッセージ
+          # @param [String] server サーバ
+          # @param [String] comment コメント
+          # @return [void]
+          def disconnected(m, server, comment)
+            if m.channel == @testchannel
+              log_incoming(m)
+              notice_on_each_channel(
+                @generator.disconnected(server, m.time, comment)
+              )
+            end
+          end
+
+          # サーバーへの接続が完了したとき、情報を集める
+          # @param [Cinch::Message] m メッセージ
+          # @return [void]
+          def connected(m)
+            sleep 1
+            @generator.connection_datas = {
+              host: bot.host,
+              nick: bot.nick,
+              network: bot.irc.isupport['NETWORK']
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rgrb/plugin/server_connection_report/generator_spec.rb
+++ b/spec/rgrb/plugin/server_connection_report/generator_spec.rb
@@ -13,7 +13,7 @@ describe RGRB::Plugin::ServerConnectionReport::Generator do
     end
 
     context 'irc.kazagakure.net' do
-      subject { generator.joined('irc.kazagakure.net', 'connected') }
+      subject { generator.joined('irc.kazagakure.net', Date.new, 'connected') }
       it { should eq('!! irc.kazagakure.net がネットワークに参加しました (connected)') }
     end
   end
@@ -28,6 +28,7 @@ describe RGRB::Plugin::ServerConnectionReport::Generator do
       subject do
         generator.disconnected(
           'irc.kazagakure.net',
+          Date.new,
           'Remote host closed the connection'
         )
       end


### PR DESCRIPTION
issue #53 
charybdis の出力を利用してサーバーの接続・切断を検知・通知するアダプターのみ、実装完了した。
今後、#53 にて他のデーモン用アダプターやSPECの更新などを行なう。