### PR TITLE
必要なパッケージの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ gem install bundler
 * gcc-c++
 * libicu-devel
 * zlib-devel
+* which
 
 ```bash
 cd /path/to/rgrb


### PR DESCRIPTION
gem "charlock_holmes" 0.7.3 をビルドするために、which コマンドが必要でした。
