### PR TITLE
Travis-CI のチェック対象を変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ cache: bundler
 bundler_args: --deployment
 rvm:
   - 2.1.10
-  - 2.2.3
-  - 2.2.5
-  - 2.3.0
+  - 2.2.6
   - 2.3.1
+  - 2.3.3
 notifications:
   irc:
     use_notice: true


### PR DESCRIPTION
Ruby 2.2.3/2.2.5/2.3.0 でのチェックを廃止し、2.2.6/2.3.3 でのチェックを増やした。