### PR TITLE
spec_t-net2services: 廃止されたサーバを削除し、IRC管理サービス用サーバを追加

### DIFF
--- a/spec/rgrb/plugin/server_connection_report/atheme_services/irc_adapter_spec.rb
+++ b/spec/rgrb/plugin/server_connection_report/atheme_services/irc_adapter_spec.rb
@@ -12,7 +12,7 @@ describe RGRB::Plugin::ServerConnectionReport::AthemeServices::IrcAdapter do
     'irc.r-roman.net',
     'irc.sougetu.net',
     'irc.trpg.net',
-    't-net.xyz'
+    'services.cre.jp'
   ]
 
   describe 'SERVER_ADD_RE' do

--- a/spec/rgrb/plugin/server_connection_report/charybdis/irc_adapter_spec.rb
+++ b/spec/rgrb/plugin/server_connection_report/charybdis/irc_adapter_spec.rb
@@ -12,13 +12,13 @@ describe RGRB::Plugin::ServerConnectionReport::Charybdis::IrcAdapter do
     'irc.r-roman.net',
     'irc.sougetu.net',
     'irc.trpg.net',
-    't-net.xyz'
+    'services.cre.jp'
   ]
 
   describe 'NETJOIN_RE' do
     shared_examples 'netjoin' do |server|
       context(server) do
-        let(:message) { "*** Notice -- Netjoin irc.cre.ne.jp <-> #{server} (0S 0C)" }
+        let(:message) { "*** Notice -- Netjoin irc.cre.jp <-> #{server} (0S 0C)" }
 
         it 'マッチする' do
           expect(message).to match(described_class::NETJOIN_RE)
@@ -41,7 +41,7 @@ describe RGRB::Plugin::ServerConnectionReport::Charybdis::IrcAdapter do
       context(server) do
         let(:comment) { 'some comment' }
         let(:message) do
-          "*** Notice -- Netsplit irc.cre.ne.jp <-> #{server} (0S 0C) (#{comment})"
+          "*** Notice -- Netsplit irc.cre.jp <-> #{server} (0S 0C) (#{comment})"
         end
 
         it 'マッチする' do

--- a/spec/rgrb/plugin/server_connection_report/ngircd/irc_adapter_spec.rb
+++ b/spec/rgrb/plugin/server_connection_report/ngircd/irc_adapter_spec.rb
@@ -12,7 +12,7 @@ describe RGRB::Plugin::ServerConnectionReport::Ngircd::IrcAdapter do
     'irc.r-roman.net',
     'irc.sougetu.net',
     'irc.trpg.net',
-    't-net.xyz'
+    'services.cre.jp'
   ]
 
   describe 'REGISTERED_RE' do


### PR DESCRIPTION
irc.cre.jp 系IRCサーバ群において、t-net.xyz サーバが廃止され、またIRC管理サービス services.cre.jp が接続されている現状に合わせるため、Rspec スクリプトを更新した。