### PR TITLE
Ruby2.4.1 リリース

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.1
   - 2.3.3
   - 2.4.0
+  - 2.4.1
 notifications:
   irc:
     use_notice: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
+    activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -56,7 +56,7 @@ GEM
     minitest (5.10.1)
     multipart-post (2.0.0)
     naught (1.1.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -81,7 +81,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.47.1)
+    rubocop (0.48.0)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -97,7 +97,7 @@ GEM
     simplecov-html (0.10.0)
     slop (3.6.0)
     sysexits (1.2.0)
-    term-ansicolor (1.4.0)
+    term-ansicolor (1.4.1)
       tins (~> 1.0)
     thor (0.19.4)
     thread_safe (0.3.6)
@@ -113,7 +113,7 @@ GEM
       memoizable (~> 0.4.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -149,4 +149,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.14.5
+   1.14.6


### PR DESCRIPTION
Travis-CI でチェックする Ruby 実行環境に、2017年3月22日にリリースされた v2.4.1 を追加した。
また、同時に使用しているライブラリを、2017年3月26日時点での最新版に更新した。

https://www.ruby-lang.org/ja/news/2017/03/22/ruby-2-4-1-released/