### PR TITLE
BCDice: ダイスボット検索処理を追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,10 @@ group :test do
 end
 
 # パス設定
-lib_path = File.expand_path('lib', File.dirname(__FILE__))
-$LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
+[
+  'lib',
+  'vendor'
+].each do |lib_name|
+  lib_path = File.expand_path(lib_name, File.dirname(__FILE__))
+  $LOAD_PATH.unshift lib_path unless $LOAD_PATH.include?(lib_path)
+end

--- a/lib/rgrb/plugin/bcdice/constants.rb
+++ b/lib/rgrb/plugin/bcdice/constants.rb
@@ -1,0 +1,18 @@
+# vim: fileencoding=utf-8
+
+module RGRB
+  module Plugin
+    module Bcdice
+      # 空白の連続を示す正規表現
+      SPACES_RE = /[\s　]+/o
+
+      # ダイスコマンドを示す正規表現
+      DICE_COMMAND_RE = %r{[-+*/()<>=\[\].@\w]+}
+      # ゲームタイトルを示す正規表現
+      GAME_TITLE_RE = /[\x21-\x7E]+/
+
+      # BCDice呼び出しの正規表現
+      BCDICE_RE = /#{SPACES_RE}(#{DICE_COMMAND_RE})(?:#{SPACES_RE}(#{GAME_TITLE_RE}))?\z/o
+    end
+  end
+end

--- a/lib/rgrb/plugin/bcdice/irc_adapter.rb
+++ b/lib/rgrb/plugin/bcdice/irc_adapter.rb
@@ -2,6 +2,7 @@
 
 require 'cinch'
 require 'rgrb/plugin/util/notice_multi_lines'
+require 'rgrb/plugin/bcdice/constants'
 
 # NOTE: BCDiceをlibディレクトリに入れれば指定が楽になりそう
 # 例：require 'BCDice/src/cgiDiceBot'
@@ -17,17 +18,6 @@ module RGRB
       class IrcAdapter
         include Cinch::Plugin
         include Util::NoticeMultiLines
-
-        # 空白の連続を示す正規表現
-        SPACES_RE = /[\s　]+/o
-
-        # ダイスコマンドを示す正規表現
-        DICE_COMMAND_RE = %r{[-+*/()<>=\[\].@\w]+}
-        # ゲームタイトルを示す正規表現
-        GAME_TITLE_RE = /[\x21-\x7E]+/
-
-        # BCDice呼び出しの正規表現
-        BCDICE_RE = /#{SPACES_RE}(#{DICE_COMMAND_RE})(?:#{SPACES_RE}(#{GAME_TITLE_RE}))?\z/o
 
         set(plugin_name: 'Bcdice')
         self.prefix = '.bcdice'

--- a/lib/rgrb/plugin/bcdice/irc_adapter.rb
+++ b/lib/rgrb/plugin/bcdice/irc_adapter.rb
@@ -18,10 +18,8 @@ module RGRB
         include Cinch::Plugin
         include Util::NoticeMultiLines
 
-        # 空白（半角＋全角）を示す正規表現
-        SP_RE = /[\s　]/
         # 空白の連続を示す正規表現
-        SPS_RE = /#{SP_RE}+/o
+        SPACES_RE = /[\s　]+/o
 
         # ダイスコマンドを示す正規表現
         DICE_COMMAND_RE = %r{[-+*/()<>=\[\].@\w]+}
@@ -29,7 +27,7 @@ module RGRB
         GAME_TITLE_RE = /[\x21-\x7E]+/
 
         # BCDice呼び出しの正規表現
-        BCDICE_RE = /#{SPS_RE}(#{DICE_COMMAND_RE})(?:#{SPS_RE}(#{GAME_TITLE_RE}))?\z/o
+        BCDICE_RE = /#{SPACES_RE}(#{DICE_COMMAND_RE})(?:#{SPACES_RE}(#{GAME_TITLE_RE}))?\z/o
 
         set(plugin_name: 'Bcdice')
         self.prefix = '.bcdice'

--- a/lib/rgrb/plugin/bcdice/irc_adapter.rb
+++ b/lib/rgrb/plugin/bcdice/irc_adapter.rb
@@ -6,9 +6,9 @@ require 'rgrb/plugin/bcdice/constants'
 
 # NOTE: BCDiceをlibディレクトリに入れれば指定が楽になりそう
 # 例：require 'BCDice/src/cgiDiceBot'
-require 'rgrb/../../vendor/BCDice/src/cgiDiceBot'
-require 'rgrb/../../vendor/BCDice/src/diceBot/DiceBotLoader'
-require 'rgrb/../../vendor/BCDice/src/diceBot/DiceBotLoaderList'
+require 'BCDice/src/cgiDiceBot'
+require 'BCDice/src/diceBot/DiceBotLoader'
+require 'BCDice/src/diceBot/DiceBotLoaderList'
 
 module RGRB
   module Plugin

--- a/lib/rgrb/plugin/bcdice/irc_adapter.rb
+++ b/lib/rgrb/plugin/bcdice/irc_adapter.rb
@@ -3,7 +3,11 @@
 require 'cinch'
 require 'rgrb/plugin/util/notice_multi_lines'
 
+# NOTE: BCDiceをlibディレクトリに入れれば指定が楽になりそう
+# 例：require 'BCDice/src/cgiDiceBot'
 require 'rgrb/../../vendor/BCDice/src/cgiDiceBot'
+require 'rgrb/../../vendor/BCDice/src/diceBot/DiceBotLoader'
+require 'rgrb/../../vendor/BCDice/src/diceBot/DiceBotLoaderList'
 
 module RGRB
   module Plugin
@@ -14,9 +18,22 @@ module RGRB
         include Cinch::Plugin
         include Util::NoticeMultiLines
 
+        # 空白（半角＋全角）を示す正規表現
+        SP_RE = /[\s　]/
+        # 空白の連続を示す正規表現
+        SPS_RE = /#{SP_RE}+/o
+
+        # ダイスコマンドを示す正規表現
+        DICE_COMMAND_RE = %r{[-+*/()<>=\[\].@\w]+}
+        # ゲームタイトルを示す正規表現
+        GAME_TITLE_RE = /[\x21-\x7E]+/
+
+        # BCDice呼び出しの正規表現
+        BCDICE_RE = /#{SPS_RE}(#{DICE_COMMAND_RE})(?:#{SPS_RE}(#{GAME_TITLE_RE}))?\z/o
+
         set(plugin_name: 'Bcdice')
         self.prefix = '.bcdice'
-        match(/[\s　]+([A-z0-9+\-*\/()<>=\[\]\.@]+)(?:[\s　]+([A-z0-9]+)|$)/, method: :bcdice)
+        match(BCDICE_RE, method: :bcdice)
         match(/-version/, method: :version)
 
         def initialize(*args)
@@ -29,22 +46,50 @@ module RGRB
         # BCDice でダイスを振る
         # @param [Cinch::Message] m 送信されたメッセージ
         # @param [String] command ダイスコマンド
-        # @param [String] gameType ゲームタイプ
+        # @param [String] specified_game_title 指定されたゲームタイトル
         # @return [void]
-        def bcdice(m, command, gameType)
-          gameType = "diceBot" if gameType == nil
+        def bcdice(m, command, specified_game_title)
           log_incoming(m)
 
-          header = "#{@header}->#{m.user.nick}"
-          result = @bcdice.roll(command, gameType)
-          if result[0] == ''
-            messages = '指定されたゲームシステム名は間違っています'
-          else
-            gameHeader, messages = result[0].lstrip.split(' : ', 2)
-            header << "[#{gameHeader}]: "
+          # 共通のヘッダ
+          header_common = "#{@header}[#{m.user.nick}]"
+
+          # ゲームタイトルが指定されていなかったら DiceBot にする
+          game_title = specified_game_title || 'DiceBot'
+          # ダイスボットを探す
+          dice_bot = DiceBotLoaderList.find(game_title)&.loadDiceBot ||
+            DiceBotLoader.loadUnknownGame(game_title)
+
+          unless dice_bot
+            # ダイスボットが見つからなかった場合は中断する
+            message = "#{header_common}: " \
+              "ゲームシステム「#{game_title}」は見つかりませんでした"
+
+            log_notice(m.target, message)
+            m.target.send(message, true)
+
+            return
           end
 
-          notice_multi_lines(messages.lines, m.target, header)
+          # ゲームシステム名を含むヘッダ
+          header = "#{header_common}<#{dice_bot.gameName}>: "
+
+          result, _ = @bcdice.roll(command, game_title)
+
+          if result.empty?
+            # 結果が返ってこなかった場合は中断する
+            message = "#{header}コマンド「#{command}」は無効です"
+
+            log_notice(m.target, message)
+            m.target.send(message, true)
+
+            return
+          end
+
+          # 結果の行の配列
+          message_lines = result.lstrip.split(' : ', 2)[1].lines
+
+          notice_multi_lines(message_lines, m.target, header)
         end
 
         # git submodule で組み込んでいる BCDice のバージョンを出力する


### PR DESCRIPTION
refs #92

ゲームシステムが見つからない、コマンドが無効の2種類のエラーが
考えられるため、それぞれの判定処理を加える。

ヘッダはランダムジェネレータを参考にして

    BCDice[ユーザ名]<ゲームシステム名>

に設定する。