### PR TITLE
IRC ボットの QUIT メッセージを変えられるようにした

### DIFF
--- a/config/rgrb.yaml
+++ b/config/rgrb.yaml
@@ -25,6 +25,10 @@ IRCBot:
   Channels:
     - ''
 
+  # QUIT メッセージ
+  # 空文字列にすると、"Caught <signal>" が設定される
+  QuitMessage: 'bye'
+
 # 使用するプラグインを列挙する。大文字小文字を区別するので注意
 Plugins:
   - DiceRoll

--- a/lib/rgrb/exec/irc_bot.rb
+++ b/lib/rgrb/exec/irc_bot.rb
@@ -34,7 +34,7 @@ module RGRB
           config, irc_adapters, plugin_options, log_level, logger
         )
 
-        set_signal_handler(bot)
+        set_signal_handler(bot, config.irc_bot['QuitMessage'])
         bot.start
 
         logger.warn('ボットは終了しました')
@@ -227,15 +227,16 @@ module RGRB
 
       # シグナルハンドラを設定する
       # @param [Cinch::Bot] bot IRC ボット
+      # @param [String] quit QUIT メッセージ
       # @return [void]
-      def set_signal_handler(bot)
+      def set_signal_handler(bot, quit)
         # シグナルを捕捉し、ボットを終了させる処理
         # trap 内で普通に bot.quit すると ThreadError が出るので
         # 新しい Thread で包む
         %i(SIGINT SIGTERM).each do |signal|
           Signal.trap(signal) do
             Thread.new(signal) do |sig|
-              bot.quit("Caught #{sig}")
+              bot.quit(quit.empty? ? "Caught #{sig}" : quit)
             end
           end
         end


### PR DESCRIPTION
稼働中のボットの切断メッセージにシステムシグナルが出て欲しくなかったため、設定ファイルで任意の文字列を設定できるようにしました。
設定ファイルの書き換えが必要です。