### PR TITLE
UrlFetchTitle: rescueの構文を間違えていた箇所を修正する

### DIFF
--- a/lib/rgrb/plugin/url_fetch_title/generator.rb
+++ b/lib/rgrb/plugin/url_fetch_title/generator.rb
@@ -179,7 +179,7 @@ module RGRB
             html_encoding =
               GuessHtmlEncoding::HTMLScanner.new(html_code).encoding
             encodings << html_encoding if html_encoding
-          rescue guess_html_encoding_error
+          rescue => guess_html_encoding_error
             logger.debug(
               "GuessHtmlEncoding error: #{guess_html_encoding_error}"
             )
@@ -206,7 +206,7 @@ module RGRB
             begin
               doc = Nokogiri::HTML(html_code, nil, encoding)
               return doc unless encoding_error?(doc)
-            rescue e
+            rescue => e
               logger.debug("Nokogiri::HTML error: #{e}")
             end
           end


### PR DESCRIPTION
`rescue` の構文を間違えていたためエラーが発生していた箇所を修正しました。これにより、以下のようなエラーの発生を防ぐことができます：

https://log.irc.cre.jp/channels/write-ex2/2018/08/12#c1431790

具体的には、`rescue e` ではなく `rescue => e` が正しいというものでした。例外を変数に格納するためには `=>` が必要でした。