### PR TITLE
Travis-CIのチェックが、ruby260 で失敗するバグを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443
   - gem update --system
+  - gem update --no-document
 notifications:
   irc:
     use_notice: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.6.0
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443
-  - gem update --system
+  - gem update --system --no-document
   - gem update --no-document
 notifications:
   irc:


### PR DESCRIPTION
bundler 2.0 系列がインストールされないためにエラー終了していた。
before_install で gem update を実行することで、エラーが起こらないように修正した。