### PR TITLE
.travis.yml: Ruby 2.3.8をテスト対象から外す

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 bundler_args: --deployment
 rvm:
-  - 2.3.8
   - 2.4.6
   - 2.5.5
   - 2.6.2


### PR DESCRIPTION
Ruby 2.3系がEOLとなっていたので、テスト対象から外しました。