### PR TITLE
BCDice の URL を新しい物に変更した

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/BCDice"]
 	path = vendor/BCDice
-	url = https://github.com/torgtaitai/BCDice.git
+	url = https://github.com/bcdice/BCDice.git


### PR DESCRIPTION
ついでに、バージョンはついていませんが、2019-07-07 現在の最新版に更新しました。