### PR TITLE
IRCボット：シグナル受信で正常に終了しない問題を修正する

### DIFF
--- a/lib/rgrb/exec/irc_bot.rb
+++ b/lib/rgrb/exec/irc_bot.rb
@@ -34,7 +34,7 @@ module RGRB
           config, irc_adapters, plugin_options, log_level, logger
         )
 
-        set_signal_handler(bot, config.irc_bot['QuitMessage'])
+        set_signal_handler(bot, config.irc_bot['QuitMessage'].to_s)
         bot.start
 
         logger.warn('ボットは終了しました')


### PR DESCRIPTION
先日の https://github.com/cre-ne-jp/log-archiver/pull/149 とほぼ同じ修正です。

IRCボットにおいて、`config.irc_bot['QuitMessage']` が設定されていない（nilになる）場合など、終了メッセージがStringでない場合にシグナルハンドラでエラーが発生し、終了できなくなります。`Object#to_s` を使って以上の問題を防ぎます。