### PR TITLE
secret-dice: Gemfileにdbmを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'mail', '~> 2.7'
 
 group :irc do
   gem 'cinch'
+
+  # DiceRollプラグインで使用する
+  gem 'dbm'
 end
 
 group :discord do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     d1lcs (0.5.5)
+    dbm (1.0.0)
     diff-lcs (1.3)
     discordrb (3.3.0)
       discordrb-webhooks (~> 3.3.0)
@@ -160,6 +161,7 @@ DEPENDENCIES
   cinch
   coveralls
   d1lcs
+  dbm
   discordrb
   guess_html_encoding
   http (> 0.9)
@@ -176,4 +178,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
`bundle update` でdbmを更新できるようにするため、Gemfileにdbmを追加しました。dbmはRubyに標準で添付されていますが、最近gem化されたため、このようにできるようになりました。

参考：[Feature #13201: Gemify dbm - Ruby master - Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/13201)