### PR TITLE
secret-dice: Gemfileにgdbmを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'mail', '~> 2.7'
 
 group :irc do
   gem 'cinch'
+
+  # DiceRollプラグインで使用する
+  gem 'gdbm'
 end
 
 group :discord do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
     equalizer (0.0.11)
     event_emitter (0.2.6)
     ffi (1.11.1)
+    gdbm (2.0.0)
     guess_html_encoding (0.0.11)
     hashdiff (0.4.0)
     http (3.3.0)
@@ -161,6 +162,7 @@ DEPENDENCIES
   coveralls
   d1lcs
   discordrb
+  gdbm
   guess_html_encoding
   http (> 0.9)
   lumberjack (~> 1.0)
@@ -176,4 +178,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
#136 の立て直しです。

`bundle update` でdbmを更新できるようにするため、Gemfileにgdbmを追加しました。gdbmはRubyに標準で添付されていますが、最近gem化されたため、このようにできるようになりました。

参考：[Feature #13248: Gemify gdbm - Ruby master - Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/13248)