### PR TITLE
Secret dice mkdir p

### DIFF
--- a/lib/rgrb/plugin/dice_roll/generator.rb
+++ b/lib/rgrb/plugin/dice_roll/generator.rb
@@ -5,6 +5,7 @@ require 'rgrb/plugin/dice_roll/dice_roll_result'
 
 require 'gdbm'
 require 'json'
+require 'fileutils'
 
 module RGRB
   module Plugin
@@ -132,7 +133,7 @@ module RGRB
         def prepare_db_dir
           unless FileTest.exist?(@db_dir)
             # 存在しなければ、ディレクトリを作成する
-            Dir.mkdir(@db_dir)
+            FileUtils.mkdir_p(@db_dir)
           else
             unless FileTest.directory?(@db_dir)
               # ディレクトリ以外のファイルが存在したらエラー

--- a/lib/rgrb/plugin/dice_roll/generator.rb
+++ b/lib/rgrb/plugin/dice_roll/generator.rb
@@ -15,10 +15,15 @@ module RGRB
       # DiceRoll の出力テキスト生成器
       class Generator
         include ConfigurableGenerator
+
+        # ダイス数が多すぎた場合のメッセージ
+        # @return [String]
         EXCESS_DICE_MESSAGE = "ダイスが机から落ちてしまいましたの☆"
 
+        # ジェネレータを初期化する
         def initialize
           super
+
           @random = Random.new
           @mutex_secret_dice = Mutex.new
         end
@@ -131,7 +136,7 @@ module RGRB
           else
             unless FileTest.directory?(@db_dir)
               # ディレクトリ以外のファイルが存在したらエラー
-              raise RuntimeError
+              raise Errno::ENOTDIR, @db_dir
             end
           end
         end

--- a/spec/rgrb/plugin/dice_roll/generator_spec.rb
+++ b/spec/rgrb/plugin/dice_roll/generator_spec.rb
@@ -3,6 +3,8 @@
 require_relative '../../../spec_helper'
 require 'rgrb/plugin/dice_roll/generator'
 
+require 'fileutils'
+
 describe RGRB::Plugin::DiceRoll::Generator do
   let(:generator) { described_class.new }
 
@@ -125,6 +127,51 @@ describe RGRB::Plugin::DiceRoll::Generator do
           expect( (1..second).include?(values[1]) ).to be(true)
         end
       end
+    end
+  end
+
+  describe 'データベースディレクトリの準備' do
+    let(:data_path_on_test) { File.expand_path('./data', __dir__) }
+
+    let(:generator_set_data_path) {
+      g = generator
+
+      g.config_id = 'test'
+      g.data_path = data_path_on_test
+      g.configure({ 'JaDice' => true })
+
+      g
+    }
+
+    before do
+      clean_data
+    end
+
+    after do
+      clean_data
+    end
+
+    it 'ディレクトリが存在しなければ作成する' do
+      expect(File.directory?("#{data_path_on_test}/test")).to be(false)
+
+      generator_set_data_path
+
+      expect(File.directory?("#{data_path_on_test}/test")).to be(true)
+    end
+
+    it 'ディレクトリ以外のファイルが存在したら例外を発生させる' do
+      expect(File.directory?("#{data_path_on_test}/test")).to be(false)
+
+      FileUtils.touch("#{data_path_on_test}/test")
+
+      expect { generator_set_data_path }.to raise_error(Errno::ENOTDIR)
+    end
+
+    private
+
+    # テスト用のデータディレクトリ内のファイルを削除する
+    def clean_data
+      FileUtils.rm_rf(Dir.glob("#{data_path_on_test}/*"))
     end
   end
 end


### PR DESCRIPTION
69a0fd4d94775f518506cd51c790dd6cc8ce125e の前で、データベースディレクトリ準備のエラーが発生していたため、テストを追加しました。また、親ディレクトリがない場合でもディレクトリが作成できるように、`FileUtils.mkdir_p`（`mkdir -p` と同じ処理）を使うようにしてみました。