### PR TITLE
DiceRoll: テスト「出目に偏りがない」で失敗する確率を減らす

### DIFF
--- a/spec/rgrb/plugin/dice_roll/generator_spec.rb
+++ b/spec/rgrb/plugin/dice_roll/generator_spec.rb
@@ -90,14 +90,11 @@ describe RGRB::Plugin::DiceRoll::Generator do
       end
     end
 
-    # 100000d101 の出目に偏りがないことを
+    # 100000d100 の出目に偏りがないことを
     # カイ二乗検定で確かめる
-    #
-    # 面数が 101 なのは、自由度が面数 - 1 で、カイ二乗分布表には
-    # 切りの良い 100 しか載っていないから
     it '出目に偏りがない' do
       rolls = 100_000
-      sides = 101
+      sides = 100
       freq = Array.new(sides, 0)
       values = generator.dice_roll(rolls, sides).values
 
@@ -109,9 +106,9 @@ describe RGRB::Plugin::DiceRoll::Generator do
       expected_count = rolls.to_f / sides
       chi2 = freq.
         map { |count| (count - expected_count)**2 / expected_count }.
-        reduce(0, :+)
+        reduce(0, &:+)
 
-      expect(chi2).to be <= 140.169 # 自由度 100、有意水準 0.5%
+      expect(chi2).to be <= 170.798 # 自由度 99、有意水準 0.001%
     end
   end
 


### PR DESCRIPTION
DiceRollのテスト「出目に偏りがない」の閾値を緩くすることで、意に反してテストが失敗する確率を大幅に減らしました。正しい分布の場合に失敗する確率が10万分の1まで低下しました（これまでの失敗確率は2000回に1回でした）。このように変更しても、出目が固定されるといったバグは確実に検出できます。