### PR TITLE
ServerConnectionReport::Test: テストメールであることをメールの件名・本文に明記する

### DIFF
--- a/lib/rgrb/plugin/server_connection_report/test/irc_adapter.rb
+++ b/lib/rgrb/plugin/server_connection_report/test/irc_adapter.rb
@@ -47,6 +47,9 @@ module RGRB
 
             config_data = config[:plugin]
             @test_channel = config_data['TestChannel'] || '#irc_test'
+
+            @mail_generator.subject = "[TEST] #{@mail_generator.subject}"
+            @mail_generator.body = "This is TEST mail.\nby #{self.class.to_s}\n\n--\n#{@mail_generator.body}"
           end
 
           # ネットワークにあるサーバが参加したときの処理


### PR DESCRIPTION
fix #144 

以下のようなメールを送るよう、変更しました。

```mail
subject: "[TEST] IRC サーバ接続通知 (irc.kazagakure.net)"
This is TEST mail.
by RGRB::Plugin::ServerConnectionReport::Test::IrcAdapter

--
"irc.kazagakure.net" がネットワークに参加しました。
```