### PR TITLE
アダプターの設定を渡すオブジェクトを Hash から Struct に変更

### DIFF
--- a/lib/rgrb/exec/discord_bot.rb
+++ b/lib/rgrb/exec/discord_bot.rb
@@ -8,6 +8,7 @@ require 'sysexits'
 require 'rgrb/version'
 require 'rgrb/config'
 require 'rgrb/plugins_loader'
+require 'rgrb/plugin_base/adapter_options'
 
 module RGRB
   module Exec
@@ -98,11 +99,12 @@ module RGRB
           plugin_name = adapter.plugin_name
           plugin_config = config.plugin_config[plugin_name] || {}
 
-          plugin_options[adapter] = {
-            root_path: root_path,
-            plugin: plugin_config,
-            config_id: config.id
-          }
+          plugin_options[adapter] = PluginBase::AdapterOptions.new(
+            config.id,
+            root_path,
+            plugin_config,
+            logger
+          )
 
           logger.warn(
             "プラグイン #{plugin_name} の設定を読み込みました"

--- a/lib/rgrb/exec/irc_bot.rb
+++ b/lib/rgrb/exec/irc_bot.rb
@@ -8,6 +8,7 @@ require 'sysexits'
 require 'rgrb/version'
 require 'rgrb/config'
 require 'rgrb/plugins_loader'
+require 'rgrb/plugin_base/adapter_options'
 
 module RGRB
   module Exec
@@ -98,12 +99,12 @@ module RGRB
           plugin_name = adapter.plugin_name
           plugin_config = config.plugin_config[plugin_name] || {}
 
-          plugin_options[adapter] = {
-            root_path: root_path,
-            plugin: plugin_config,
-            config_id: config.id,
-            logger: logger
-          }
+          plugin_options[adapter] = PluginBase::AdapterOptions.new(
+            config.id,
+            root_path,
+            plugin_config,
+            logger
+          )
 
           logger.warn(
             "プラグイン #{plugin_name} の設定を読み込みました"

--- a/lib/rgrb/plugin_base/adapter.rb
+++ b/lib/rgrb/plugin_base/adapter.rb
@@ -12,12 +12,12 @@ module RGRB
         generator_class = Object.const_get(class_name_tree.join('::'))
         @generator = generator_class.new
 
-        @generator.config_id = config[:config_id]
-        @generator.root_path = config[:root_path]
-        @generator.logger = config[:logger]
+        @generator.config_id = config.id
+        @generator.root_path = config.root_path
+        @generator.logger = config.logger
 
         # プラグインをロガーとして使えるよう、設定に含める
-        config_data = config[:plugin].merge({ logger: self })
+        config_data = config.plugin.merge({ logger: self })
         @generator.configure(config_data)
 
         true

--- a/lib/rgrb/plugin_base/adapter_options.rb
+++ b/lib/rgrb/plugin_base/adapter_options.rb
@@ -1,0 +1,12 @@
+# vim: fileencoding=utf-8
+
+module RGRB
+  module PluginBase
+    AdapterOptions = Struct.new(
+      :id,
+      :root_path,
+      :plugin,
+      :logger,
+    )
+  end
+end

--- a/spec/rgrb/plugin/configurable_spec.rb
+++ b/spec/rgrb/plugin/configurable_spec.rb
@@ -4,6 +4,7 @@ require_relative '../../spec_helper'
 
 require 'rgrb/plugin_base/generator'
 require 'rgrb/plugin_base/adapter'
+require 'rgrb/plugin_base/adapter_options'
 
 module RGRB
   module Plugin
@@ -28,12 +29,14 @@ module RGRB
         attr_reader :generator
 
         def config
-          {
-            root_path: '/home/rgrb',
-            plugin: {
+          PluginBase::AdapterOptions.new(
+            'test',
+            '/home/rgrb',
+            {
               'name' => 'RGRB'
-            }
-          }
+            },
+            Lumberjack::Logger.new($stdout, progname: self.class.to_s)
+          )
         end
       end
     end


### PR DESCRIPTION
fix #132 

名前を RGRB::PluginBase::AdapterOptions にしてみたが、RGRB::Config 等と同様の名前空間においた方が良かっただろうか。