### PR TITLE
ServerConnectionReport: ボットが出力するログの形式と、IRC からの応答のログの形式を分離した

### DIFF
--- a/lib/rgrb/plugin/server_connection_report/irc_adapter_methods.rb
+++ b/lib/rgrb/plugin/server_connection_report/irc_adapter_methods.rb
@@ -35,9 +35,9 @@ module RGRB
               config_data['MessageTemplate']
             )
 
-            warn('メール送信を行います')
+            @logger.warn('メール送信を行います')
           else
-            warn('メール送信を行いません')
+            @logger.warn('メール送信を行いません')
           end
 
           self

--- a/lib/rgrb/plugin_base/adapter.rb
+++ b/lib/rgrb/plugin_base/adapter.rb
@@ -4,6 +4,15 @@ module RGRB
   module PluginBase
     # アダプターの共通モジュール
     module Adapter
+      def initialize(*)
+        super
+
+        @config_id = config.id
+        @root_path = config.root_path
+        @plugin_config = config.plugin
+        @logger = config.logger
+      end
+
       # 生成器を用意し、設定を転送する
       # @return [true]
       def prepare_generator


### PR DESCRIPTION
fix #74 

PluginBase::Adapter のコンストラクタに、アダプターでもプラグイン設定を使えるような仕組みを導入した。

そもそも当該のログ出力メッセージはわかりづらいでしょうか。
この時にはメールを送信しておらず、メールの送信準備ができた段階です。