### PR TITLE
BCDice のバージョン番号を、IRC 応答に追加

### DIFF
--- a/lib/rgrb/plugin/bcdice/generator.rb
+++ b/lib/rgrb/plugin/bcdice/generator.rb
@@ -23,7 +23,8 @@ module RGRB
         def initialize
           super
 
-          get_version_and_commit_id
+          @version_and_commit_id = get_version_and_commit_id
+          logger.warn("BCDice を読み込みました: #{bcdice_version}")
 
           @bcdice = CgiDiceBot.new
         end
@@ -65,21 +66,19 @@ module RGRB
         private
 
         # 起動時点での BCDice のコミット ID を取得・保存する
-        # @return [void]
+        # @return [String]
         def get_version_and_commit_id
           bcdice_path = File.expand_path('../../../../vendor/BCDice', __dir__)
           @commit_id =
             begin
               Dir.chdir(bcdice_path) do
                 `git show -s --format=%H`.strip
-              rescue
-                ''
               end
+            rescue
+                ''
             end
-          @version_and_commit_id =
-            @commit_id.empty? ? $bcDiceVersion : "#{$bcDiceVersion} (#{@commit_id})"
 
-          logger.warn(bcdice_version)
+          @commit_id.empty? ? $bcDiceVersion : "#{$bcDiceVersion} (#{@commit_id})"
         end
 
         # ダイスボットを探す

--- a/lib/rgrb/plugin/bcdice/generator.rb
+++ b/lib/rgrb/plugin/bcdice/generator.rb
@@ -1,5 +1,6 @@
 # vim: fileencoding=utf-8
 
+require 'rgrb/plugin_base/generator'
 require 'rgrb/plugin/bcdice/constants'
 require 'rgrb/plugin/bcdice/errors'
 
@@ -16,8 +17,14 @@ module RGRB
 
       # Bcdice の出力テキスト生成器
       class Generator
+        include PluginBase::Generator
+
         # 生成器を初期化する
         def initialize
+          super
+
+          get_version_and_commit_id
+
           @bcdice = CgiDiceBot.new
         end
 
@@ -52,15 +59,28 @@ module RGRB
         # git submodule で組み込んでいる BCDice のバージョンを返す
         # @return [String]
         def bcdice_version
-          bcdice_path = File.expand_path('../../../../vendor/BCDice', __dir__)
-          commit_id = Dir.chdir(bcdice_path) do
-            `git show -s --format=%H`.strip
-          end
-
-          "BCDice Commit ID: #{commit_id}"
+          "BCDice Version: #{@version_and_commit_id}"
         end
 
         private
+
+        # 起動時点での BCDice のコミット ID を取得・保存する
+        # @return [void]
+        def get_version_and_commit_id
+          bcdice_path = File.expand_path('../../../../vendor/BCDice', __dir__)
+          @commit_id =
+            begin
+              Dir.chdir(bcdice_path) do
+                `git show -s --format=%H`.strip
+              rescue
+                ''
+              end
+            end
+          @version_and_commit_id =
+            @commit_id.empty? ? $bcDiceVersion : "#{$bcDiceVersion} (#{@commit_id})"
+
+          logger.warn(bcdice_version)
+        end
 
         # ダイスボットを探す
         # @param [String] game_type ゲームタイプ

--- a/spec/rgrb/plugin/bcdice/generator_spec.rb
+++ b/spec/rgrb/plugin/bcdice/generator_spec.rb
@@ -11,7 +11,7 @@ describe RGRB::Plugin::Bcdice::Generator do
   describe '#bcdice_version' do
     it 'BCDice のバージョンを出力する' do
       expect(generator.bcdice_version).to(
-        match(/\ABCDice Commit ID: [0-9a-f]{40}\z/)
+        match(/\ABCDice Version: [0-9]\.[0-9]{2}\.[0-9]{2} \([0-9a-f]{40}\)\z/)
       )
     end
   end


### PR DESCRIPTION
fix #157 

ついでに、RGRB 本体と同様に、起動時のコミット ID をメンバ変数に保存しておくようにしました。