### PR TITLE
ランダムジェネレータ：テストで必要なメソッドをpublicにする

### DIFF
--- a/lib/rgrb/plugin/random_generator/generator.rb
+++ b/lib/rgrb/plugin/random_generator/generator.rb
@@ -31,7 +31,7 @@ module RGRB
         def configure(config_data)
           super
 
-          load_data("#{@data_path}/**/*.yaml")
+          load_data!("#{@data_path}/**/*.yaml")
 
           self
         end
@@ -90,6 +90,26 @@ module RGRB
           end.keys.sort
         end
 
+        # 表のデータを読み込む
+        # @param [String] glob_pattern データファイル名のパターン
+        # @return [void]
+        def load_data!(glob_pattern)
+          # 表を格納するハッシュ
+          @table = {}
+
+          Dir.glob(glob_pattern).each do |path|
+            begin
+              yaml = File.read(path, encoding: 'UTF-8')
+              table = Table.parse_yaml(yaml)
+
+              @table[table.name] = table
+            rescue => e
+              logger.error("データファイル #{path} の読み込みに失敗しました")
+              logger.error(e)
+            end
+          end
+        end
+
         private
 
         # 表から値を取得して返す
@@ -139,26 +159,6 @@ module RGRB
           end
 
           str
-        end
-
-        # 表のデータを読み込む
-        # @param [String] glob_pattern データファイル名のパターン
-        # @return [void]
-        def load_data(glob_pattern)
-          # 表を格納するハッシュ
-          @table = {}
-
-          Dir.glob(glob_pattern).each do |path|
-            begin
-              yaml = File.read(path, encoding: 'UTF-8')
-              table = Table.parse_yaml(yaml)
-
-              @table[table.name] = table
-            rescue => e
-              logger.error("データファイル #{path} の読み込みに失敗しました")
-              logger.error(e)
-            end
-          end
         end
 
         # 表が存在することを確かめる

--- a/lib/rgrb/plugin/random_generator/generator.rb
+++ b/lib/rgrb/plugin/random_generator/generator.rb
@@ -162,7 +162,7 @@ module RGRB
         end
 
         # 表が存在することを確かめる
-        # @return [String] table_name 表名
+        # @param [String] table_name 表名
         # @return [true] 表が存在する場合
         # @raise [TableNotFound] 表が存在しない場合
         def check_existence_of(table_name)
@@ -172,7 +172,7 @@ module RGRB
         end
 
         # 表が公開されていることを確かめる
-        # @return [String] table_name 表名
+        # @param [String] table_name 表名
         # @return [true] 表が公開されている場合
         # @raise [PrivateTable] 表が公開されていない場合
         def check_permission_of(table_name)

--- a/spec/rgrb/plugin/random_generator/generator_spec.rb
+++ b/spec/rgrb/plugin/random_generator/generator_spec.rb
@@ -7,11 +7,11 @@ require 'rgrb/plugin/random_generator/generator'
 
 describe RGRB::Plugin::RandomGenerator::Generator do
   let(:generator) do
-    obj = described_class.new
-    obj.send(:load_data, "#{__dir__}/data/*.yaml")
-    obj.send(:logger=, Lumberjack::Logger.new($stdout, progname: self.class.to_s))
+    g = described_class.new
+    g.load_data!("#{__dir__}/data/*.yaml")
+    g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
 
-    obj
+    g
   end
 
   describe '#desc' do

--- a/spec/rgrb/plugin/server_connection_report/mail_generator_spec.rb
+++ b/spec/rgrb/plugin/server_connection_report/mail_generator_spec.rb
@@ -33,10 +33,10 @@ describe RGRB::Plugin::ServerConnectionReport::MailGenerator do
   }
 
   let(:mail_generator) {
-    obj = described_class.new
-    obj.send(:logger=, Lumberjack::Logger.new($stdout, progname: self.class.to_s))
+    g = described_class.new
+    g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
 
-    obj
+    g
   }
 
   describe '#initialize' do


### PR DESCRIPTION
ランダムジェネレータのテストにおいて、`Object#send` を使って無理矢理プライベートメソッドを呼び出していた箇所を、普通のメソッド呼び出しに変えました。おそらくこれは私がインターフェースの設計に失敗していた箇所です（テストで使う＝外部から使う ⇒ publicでなければならない）。

ついでに、server_connection_reportのmail_generatorのテストの同様の箇所も修正しました。