### PR TITLE
Bcdice: テストに失敗するようになったのを修正

### DIFF
--- a/lib/rgrb/plugin/bcdice/discord_adapter.rb
+++ b/lib/rgrb/plugin/bcdice/discord_adapter.rb
@@ -24,7 +24,7 @@ module RGRB
         def initialize(*args)
           super
 
-          @generator = Generator.new
+          prepare_generator
           @header = 'BCDice'
         end
 

--- a/lib/rgrb/plugin/bcdice/generator.rb
+++ b/lib/rgrb/plugin/bcdice/generator.rb
@@ -19,14 +19,14 @@ module RGRB
       class Generator
         include PluginBase::Generator
 
-        # 生成器を初期化する
-        def initialize
+        def configure(*)
           super
 
+          @bcdice = CgiDiceBot.new
           @version_and_commit_id = get_version_and_commit_id
           logger.warn("BCDice を読み込みました: #{bcdice_version}")
 
-          @bcdice = CgiDiceBot.new
+          self
         end
 
         # BCDice でダイスを振った結果を返す

--- a/lib/rgrb/plugin/bcdice/irc_adapter.rb
+++ b/lib/rgrb/plugin/bcdice/irc_adapter.rb
@@ -24,7 +24,7 @@ module RGRB
         def initialize(*args)
           super
 
-          @generator = Generator.new
+          prepare_generator
           @header = 'BCDice'
         end
 

--- a/spec/rgrb/plugin/bcdice/generator_spec.rb
+++ b/spec/rgrb/plugin/bcdice/generator_spec.rb
@@ -1,12 +1,26 @@
 # vim: fileencoding=utf-8
 
+require 'lumberjack'
 require_relative '../../../spec_helper'
-
 require 'rgrb/plugin/bcdice/generator'
 require 'rgrb/plugin/bcdice/errors'
 
 describe RGRB::Plugin::Bcdice::Generator do
-  let(:generator) { described_class.new }
+  let(:generator) do
+    g = described_class.new
+    g.instance_variable_set(
+      :@bcdice,
+      CgiDiceBot.new
+    )
+    g.instance_variable_set(
+      :@version_and_commit_id,
+      g.send(:get_version_and_commit_id)
+    )
+
+    g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
+
+    g
+  end
 
   describe '#bcdice_version' do
     it 'BCDice のバージョンを出力する' do


### PR DESCRIPTION
fix #154

アダプタ側でのジェネレータ読み込み方法を改善しました。
テストでの処理が複雑化してしまっていますが、他の何か良い方法はあるでしょうか。