### PR TITLE
BCDice: コンストラクタでBCDiceを用意する

### DIFF
--- a/lib/rgrb/plugin/bcdice/generator.rb
+++ b/lib/rgrb/plugin/bcdice/generator.rb
@@ -19,12 +19,20 @@ module RGRB
       class Generator
         include PluginBase::Generator
 
+        # ジェネレータを初期化する
+        def initialize
+          @bcdice = CgiDiceBot.new
+          @version_and_commit_id = get_version_and_commit_id
+        end
+
+        # プラグインがアダプタによって読み込まれた際の設定
+        #
+        # アダプタによってジェネレータが用意されたとき
+        # BCDiceのバージョン情報をログに出力する。
         def configure(*)
           super
 
-          @bcdice = CgiDiceBot.new
-          @version_and_commit_id = get_version_and_commit_id
-          logger.warn("BCDice を読み込みました: #{bcdice_version}")
+          logger.info(bcdice_version)
 
           self
         end

--- a/spec/rgrb/plugin/bcdice/generator_spec.rb
+++ b/spec/rgrb/plugin/bcdice/generator_spec.rb
@@ -8,15 +8,6 @@ require 'rgrb/plugin/bcdice/errors'
 describe RGRB::Plugin::Bcdice::Generator do
   let(:generator) do
     g = described_class.new
-    g.instance_variable_set(
-      :@bcdice,
-      CgiDiceBot.new
-    )
-    g.instance_variable_set(
-      :@version_and_commit_id,
-      g.send(:get_version_and_commit_id)
-    )
-
     g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
 
     g


### PR DESCRIPTION
テストで無理にインスタンス変数を設定しなくてもよいように、コンストラクタでBCDiceを用意するようにしました。

また、プラグイン読み込み時のBCDiceのバージョンのログの内容を調整しました。BCDiceの用意のタイミングが変わったため、「読み込みました」と出力するのではなく、以下の図のように単にバージョン情報を出力します。
<img width="1007" alt="bcdice-log-version" src="https://user-images.githubusercontent.com/2551173/62001808-7ec81100-b133-11e9-97eb-8cc2dd4c9ce3.png">
