### PR TITLE
ジェネレータに渡すロガー関連の処理の簡略化

### DIFF
--- a/lib/rgrb/plugin/server_connection_report/irc_adapter_methods.rb
+++ b/lib/rgrb/plugin/server_connection_report/irc_adapter_methods.rb
@@ -29,7 +29,7 @@ module RGRB
           if config_data['Mail'] && config_data['MessageTemplate']
             @mail_generator = MailGenerator.new
             @mail_generator.root_path = config[:root_path]
-            @mail_generator.logger = config[:logger]
+            @mail_generator.logger = self
             @mail_generator.configure(config_data)
             @mail_generator.load_mail_template_by_name(
               config_data['MessageTemplate']

--- a/lib/rgrb/plugin_base/adapter.rb
+++ b/lib/rgrb/plugin_base/adapter.rb
@@ -14,11 +14,14 @@ module RGRB
 
         @generator.config_id = config.id
         @generator.root_path = config.root_path
-        @generator.logger = config.logger
 
-        # プラグインをロガーとして使えるよう、設定に含める
-        config_data = config.plugin.merge({ logger: self })
-        @generator.configure(config_data)
+        # TODO: プラグインでのテキスト生成関連のログを専用のロガーで出力できる
+        # ようにする
+        #
+        # 現在はアダプタ自体をロガーとして使う
+        @generator.logger = self
+
+        @generator.configure(config.plugin)
 
         true
       end

--- a/lib/rgrb/plugin_base/adapter.rb
+++ b/lib/rgrb/plugin_base/adapter.rb
@@ -4,6 +4,8 @@ module RGRB
   module PluginBase
     # アダプターの共通モジュール
     module Adapter
+      private
+
       # 生成器を用意し、設定を転送する
       # @return [true]
       def prepare_generator
@@ -18,14 +20,14 @@ module RGRB
         # TODO: プラグインでのテキスト生成関連のログを専用のロガーで出力できる
         # ようにする
         #
-        # 現在はアダプタ自体をロガーとして使う
-        @generator.logger = self
+        # 注意：アダプタは必ずジェネレータ用のロガーを返す logger_for_generator
+        # メソッドを必ず定義すること。
+        @generator.logger = logger_for_generator
 
         @generator.configure(config.plugin)
 
         true
       end
-      private :prepare_generator
     end
   end
 end

--- a/lib/rgrb/plugin_base/adapter_options.rb
+++ b/lib/rgrb/plugin_base/adapter_options.rb
@@ -2,10 +2,18 @@
 
 module RGRB
   module PluginBase
+    # アダプタに渡される設定などを含む構造体
     AdapterOptions = Struct.new(
+      # 設定 ID
       :id,
+      # RGRB のルートディレクトリのパス
       :root_path,
+      # プラグインの設定
       :plugin,
+      # 将来のロガー設定用のメンバ
+      #
+      # TODO: プラグインでのテキスト生成関連のログをこのロガーで出力できる
+      # ようにする
       :logger,
     )
   end

--- a/lib/rgrb/plugin_base/generator.rb
+++ b/lib/rgrb/plugin_base/generator.rb
@@ -1,10 +1,17 @@
 # vim: fileencoding=utf-8
 
 require 'active_support/core_ext/string/inflections'
+require 'lumberjack'
 
 module RGRB
   module PluginBase
     module Generator
+      # 既定のロガー
+      # @return [Lumberjack::Logger]
+      DEFAULT_LOGGER = Lumberjack::Logger.new(
+        $stdout, progname: File.basename($PROGRAM_NAME)
+      )
+
       # 設定 ID
       # @return [String]
       attr_accessor :config_id
@@ -26,6 +33,7 @@ module RGRB
       def initialize
         class_name_tree = self.class.name.split('::')
         @plugin_name_underscore = class_name_tree[-2].underscore
+        @logger = DEFAULT_LOGGER
       end
 
       # RGRB のルートパスを設定する

--- a/lib/rgrb/plugin_base/irc_adapter.rb
+++ b/lib/rgrb/plugin_base/irc_adapter.rb
@@ -11,7 +11,7 @@ module RGRB
         by.include(Cinch::Plugin)
         by.include(Adapter)
       end
-  
+
       # メッセージを NOTICE し、ログに書き出す
       # @param [String, Cinch::Target, Array<String>, Array<Cinch::Target>]
       #   targets NOTICE 先
@@ -45,7 +45,7 @@ module RGRB
           else
             raise ArgumentError
           end
-  
+
         targets.each do |target|
           messages.each do |line|
             message = "#{header}#{line.chomp}"
@@ -54,7 +54,7 @@ module RGRB
           end
         end
       end
-  
+
       # 複数の送信先に NOTICE する
       # v1.0.5 より非推奨メソッド。send_notice に統合する。
       #
@@ -67,14 +67,14 @@ module RGRB
         send_notice(message, channels_to_send, '', safe)
         log('IrcPlugin#notice_on_each_channel: deprecated', :warn)
       end
-  
+
       # 入ってきたメッセージをログに残す
       # @param [Cinch::Message] m メッセージ
       # @return [void]
       def log_incoming(m)
         log(m.raw, :incoming, :info)
       end
-  
+
       # NOTICE をログに残す
       # @param [Cinch::Target] target NOTICE の対象
       # @param [String] message メッセージ
@@ -82,20 +82,28 @@ module RGRB
       def log_notice(target, message)
         log("<NOTICE to #{target.name}> #{message.inspect}", :outgoing, :info)
       end
-  
+
       # JOIN をログに残す
       # @param [Cinch::Channel] channel
       # @return [void]
       def log_join(channel)
         log("<JOIN on #{channel}>", :outgoing, :info)
       end
-  
+
       # PART をログに残す
       # @param [Cinch::Channel] channel
       # @param [String] message 退出メッセージ
       # @return [void]
       def log_part(channel, message)
         log("<PART from #{channel}> #{message.inspect}", :outgoing, :info)
+      end
+
+      private
+
+      # ジェネレータで使うロガーを返す
+      # @return [self]
+      def logger_for_generator
+        self
       end
     end
   end

--- a/spec/rgrb/plugin/bcdice/generator_spec.rb
+++ b/spec/rgrb/plugin/bcdice/generator_spec.rb
@@ -6,12 +6,7 @@ require 'rgrb/plugin/bcdice/generator'
 require 'rgrb/plugin/bcdice/errors'
 
 describe RGRB::Plugin::Bcdice::Generator do
-  let(:generator) do
-    g = described_class.new
-    g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
-
-    g
-  end
+  let(:generator) { described_class.new }
 
   describe '#bcdice_version' do
     it 'BCDice のバージョンを出力する' do

--- a/spec/rgrb/plugin/random_generator/generator_spec.rb
+++ b/spec/rgrb/plugin/random_generator/generator_spec.rb
@@ -9,7 +9,6 @@ describe RGRB::Plugin::RandomGenerator::Generator do
   let(:generator) do
     g = described_class.new
     g.load_data!("#{__dir__}/data/*.yaml")
-    g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
 
     g
   end

--- a/spec/rgrb/plugin/server_connection_report/mail_generator_spec.rb
+++ b/spec/rgrb/plugin/server_connection_report/mail_generator_spec.rb
@@ -32,12 +32,7 @@ describe RGRB::Plugin::ServerConnectionReport::MailGenerator do
     }
   }
 
-  let(:mail_generator) {
-    g = described_class.new
-    g.logger = Lumberjack::Logger.new($stdout, progname: self.class.to_s)
-
-    g
-  }
+  let(:mail_generator) { described_class.new }
 
   describe '#initialize' do
     it 'インスタンスを初期化することができる' do


### PR DESCRIPTION
https://github.com/cre-ne-jp/rgrb/pull/155#issuecomment-515761645 で書かれた、ジェネレータに渡すロガー関連の処理の変更です。

* ジェネレータの既定の（アダプタを使わないときの）ロガーとして、`RGRB::PluginBase::Adapter` 内に共通のロガー `DEFAULT_LOGGER` を用意します。このようにすることで、ジェネレータのテスト時にロガーを用意しなくてもよくなります。プラグインごとにロガーを作らないので、リソースの消費も少ないです。
* アダプタを使うとき、ジェネレータに以下をロガーとして渡します。
    * IRCアダプタ：アダプタ自身（アダプタに見やすいロガー機能が含まれているため）
    * Discordアダプタ：ボットが持つロガー（Cinchのように見やすいロガーが含まれていないため）