### PR TITLE
CTCP: TIMEの応答をRFC 2822形式で返す

### DIFF
--- a/lib/rgrb/plugin/ctcp/irc_adapter.rb
+++ b/lib/rgrb/plugin/ctcp/irc_adapter.rb
@@ -2,6 +2,8 @@
 
 require 'rgrb/plugin_base/irc_adapter'
 
+require 'time'
+
 module RGRB
   module Plugin
     # CTCP 応答プラグイン
@@ -35,7 +37,7 @@ module RGRB
         end
 
         def ctcp_time(m)
-          ctcp_reply(m, Time.now.strftime('%a, %d %b %Y %T %z'))
+          ctcp_reply(m, Time.now.rfc2822)
         end
 
         def ctcp_ping(m)


### PR DESCRIPTION
timeライブラリを使い、`strftime` の部分を簡潔に書きました。