### PR TITLE
CTCP: コマンド一覧の改良とコメントの追加

### DIFF
--- a/lib/rgrb/plugin/ctcp/irc_adapter.rb
+++ b/lib/rgrb/plugin/ctcp/irc_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # vim: fileencoding=utf-8
 
 require 'rgrb/plugin_base/irc_adapter'
@@ -11,23 +12,25 @@ module RGRB
         include PluginBase::IrcAdapter
 
         set(plugin_name: 'Ctcp')
-        ctcp(:clientinfo)
-        ctcp(:version)
-        ctcp(:time)
-        ctcp(:ping)
-        ctcp(:userinfo)
-        ctcp(:source)
+
+        # 利用可能な CTCP コマンド
+        AVAILABLE_COMMANDS = %w(CLIENTINFO VERSION TIME PING USERINFO SOURCE)
+          .sort
+          .freeze
+
+        AVAILABLE_COMMANDS.each do |command|
+          ctcp(command)
+        end
 
         def initialize(*args)
           super
 
           config_data = config[:plugin] || {}
           @userinfo = config_data['UserInfo'] || 'RGRB 稼働中'
-          @valid_cmd = %w(CLIENTINFO VERSION TIME PING USERINFO SOURCE).sort
         end
 
         def ctcp_clientinfo(m)
-          ctcp_reply(m, @valid_cmd.join(' '))
+          ctcp_reply(m, AVAILABLE_COMMANDS.join(' '))
         end
 
         def ctcp_version(m)

--- a/lib/rgrb/plugin/ctcp/irc_adapter.rb
+++ b/lib/rgrb/plugin/ctcp/irc_adapter.rb
@@ -22,33 +22,58 @@ module RGRB
           ctcp(command)
         end
 
-        def initialize(*args)
+        # プラグインを初期化する
+        def initialize(*)
           super
 
           config_data = config[:plugin] || {}
           @userinfo = config_data['UserInfo'] || 'RGRB 稼働中'
         end
 
+        # 利用可能なコマンドを返す
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @return [void]
+        # @see https://tools.ietf.org/id/draft-oakley-irc-ctcp-01.html#clientinfo
         def ctcp_clientinfo(m)
           ctcp_reply(m, AVAILABLE_COMMANDS.join(' '))
         end
 
+        # バージョン情報を返す
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @return [void]
+        # @see https://tools.ietf.org/id/draft-oakley-irc-ctcp-01.html#version
         def ctcp_version(m)
           ctcp_reply(m, "RGRB #{RGRB::VERSION_WITH_COMMIT_ID}")
         end
 
+        # 現在のローカル時刻を返す
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @return [void]
+        # @see https://tools.ietf.org/id/draft-oakley-irc-ctcp-01.html#time
         def ctcp_time(m)
           ctcp_reply(m, Time.now.strftime('%a, %d %b %Y %T %z'))
         end
 
+        # クエリと同じパラメータを返す
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @return [void]
+        # @see https://tools.ietf.org/id/draft-oakley-irc-ctcp-01.html#ping
         def ctcp_ping(m)
           ctcp_reply(m, m.ctcp_args.join(' '))
         end
 
+        # ユーザについての情報を返す
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @return [void]
+        # @see https://tools.ietf.org/id/draft-oakley-irc-ctcp-01.html#userinfo
         def ctcp_userinfo(m)
           ctcp_reply(m, @userinfo)
         end
 
+        # RGRB のソースコードが存在する場所を返す
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @return [void]
+        # @see https://tools.ietf.org/id/draft-oakley-irc-ctcp-01.html#source
         def ctcp_source(m)
           ctcp_reply(m, 'https://github.com/cre-ne-jp/rgrb')
         end
@@ -56,8 +81,8 @@ module RGRB
         private
 
         # CTCP 応答を返す
-        # @param [Cinch::Message] m
-        # @param [String] message 送信メッセージ
+        # @param [Cinch::Message] m 受信したメッセージ
+        # @param [String] message 送信するメッセージ
         # @return [void]
         def ctcp_reply(m, message)
           log_incoming(m)


### PR DESCRIPTION
`CLIENTINFO` で送信する、利用可能なCTCPコマンドをクラス定数で定義するようにしました。一箇所で定義して漏れがないようにする狙いです。

また、コメントを追加して、元PR #173 に記載されていたRFCドラフトの該当箇所へのリンクを示しました。