### PR TITLE
メソッド分割による処理の単純化

### DIFF
--- a/lib/rgrb/plugins_loader.rb
+++ b/lib/rgrb/plugins_loader.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # vim: fileencoding=utf-8
 
 require 'active_support/core_ext/string/inflections'
@@ -12,11 +13,9 @@ module RGRB
     # @param [Config] config RGRB の設定
     # @return [PluginsLoader]
     def initialize(config)
-      @plugin_names = config.plugins
-      @plugin_path = {}
-      @plugin_names.each do |name|
-        @plugin_path[name] = "#{PLUGINS_ROOT_PATH}/#{name.underscore}"
-      end
+      @plugin_paths = config.plugins.map { |name|
+        [name, "#{PLUGINS_ROOT_PATH}/#{name.underscore}"]
+      }
     end
 
     # プラグインの構成要素を require する
@@ -26,32 +25,46 @@ module RGRB
     #   読み込みエラー時に該当要素をスキップするか
     # @return [Array] 読み込んだプラグイン構成要素のクラスの配列
     def load_each(component_name, skip_on_load_error = false)
+      loaded_classes = component_paths(component_name).map { |class_name, path|
+        try_load(class_name, path, skip_on_load_error)
+      }
+
+      loaded_classes.compact
+    end
+
+    private
+
+    # プラグインの構成要素のパスの配列を返す
+    # @param [String, Symbol] component_name
+    #   構成要素の名前："Generator" 等
+    # @return [Array<Array<String>>] [クラス名, パス] の配列
+    def component_paths(component_name)
       component_name_underscore = component_name.to_s.underscore
-      component_path = {}
-      @plugin_path.each do |name, path|
-        component_path["#{name}::#{component_name}"] =
-          "#{path}/#{component_name_underscore}"
-      end
 
-      loaded_class = component_path.map do |class_name, path|
+      @plugin_paths.map { |name, path|
+        ["#{name}::#{component_name}", "#{path}/#{component_name_underscore}"]
+      }
+    end
+
+    # プラグインの構成要素の読み込みを試みる
+    # @param [String] class_name クラス名
+    # @param [String] プラグインのパス
+    # @param [Boolean] skip_on_load_error
+    #   読み込みエラー時に該当要素をスキップするか
+    # @return [Class] 正常に読み込めた場合、プラグインのクラスを返す
+    # @return [nil] プラグインの読み込みに失敗した場合
+    def try_load(class_name, path, skip_on_load_error)
+      begin
+        require(path)
+      rescue LoadError => e
         if skip_on_load_error
-          begin
-            require path
-          rescue LoadError
-            next nil
-          end
+          return nil
         else
-          require path
-        end
-
-        if RGRB::Plugin.const_defined?(class_name)
-          RGRB::Plugin.const_get(class_name)
-        else
-          nil
+          raise e
         end
       end
 
-      loaded_class.compact
+      RGRB::Plugin.const_get(class_name)
     end
   end
 end

--- a/spec/rgrb/plugins_loader_spec.rb
+++ b/spec/rgrb/plugins_loader_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # vim: fileencoding=utf-8
 
 require_relative '../spec_helper'
@@ -8,50 +9,21 @@ require 'rgrb/config'
 module RGRB::Plugin; end
 
 describe RGRB::PluginsLoader do
-  let(:empty_config) do
-    RGRB::Config.new('IRCBot' => {})
-  end
-  let(:empty_plugins_loader) { described_class.new(empty_config) }
-
   let(:plugin_names) { %w(DiceRoll Keyword) }
-  let(:plugin_path) do
-    {
-      'DiceRoll' => 'rgrb/plugin/dice_roll',
-      'Keyword' => 'rgrb/plugin/keyword'
-    }
-  end
-  let(:generators) do
-    plugin_names.map do |name|
-      RGRB::Plugin.const_get("#{name}::Generator")
-    end
-  end
-  let(:rgrb_config) do
+
+  let(:generators) {
+    plugin_names.map { |name| RGRB::Plugin.const_get("#{name}::Generator") }
+  }
+
+  let(:rgrb_config) {
     RGRB::Config.new('test', {'IRCBot' => {}, 'Plugins' => plugin_names})
-  end
+  }
   let(:plugins_loader) { described_class.new(rgrb_config) }
 
-  let(:wrong_config) do
+  let(:wrong_config) {
     RGRB::Config.new('test', {'IRCBot' => {}, 'Plugins' => ['MissingPlugin']})
-  end
-  let(:wrong_plugins_loader) do
-    described_class.new(wrong_config)
-  end
-
-  describe '#initialize (private)' do
-    describe '@plugin_names' do
-      it 'プラグイン名の配列に等しい' do
-        expect(plugins_loader.instance_variable_get(:@plugin_names)).
-          to eq(plugin_names)
-      end
-    end
-
-    describe '@plugin_paths' do
-      it 'プラグインのパスのハッシュに等しい' do
-        expect(plugins_loader.instance_variable_get(:@plugin_path)).
-          to eq(plugin_path)
-      end
-    end
-  end
+  }
+  let(:wrong_plugins_loader) { described_class.new(wrong_config) }
 
   describe '#load_each' do
     context '"Generator"' do


### PR DESCRIPTION
[CodeClimate](https://codeclimate.com/github/cre-ne-jp/rgrb)でCognitive Complexity（コードの複雑さ）が大きいと指摘されたメソッドを分割して、処理を単純にしました。