### PR TITLE
Travis CI: パッチバージョンを指定しない

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache: bundler
 bundler_args: --deployment
 rvm:
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.5
+  - 2.6
+  - 2.7
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443
   - yes |gem update --system --no-document


### PR DESCRIPTION
マイナーバージョンのみを指定することで、各マイナーバージョンの最新版がテストされるようにしました。

* 2.5→2.5.8
* 2.6→2.6.6
* 2.7→2.7.1
