### PR TITLE
keyword: キーワード検索の URL を、ログアーカイブのキーワード検索ページに変更

### DIFF
--- a/lib/rgrb/plugin/keyword/generator.rb
+++ b/lib/rgrb/plugin/keyword/generator.rb
@@ -12,7 +12,8 @@ module RGRB
         include PluginBase::Generator
 
         # cre.jp 検索ページの URL
-        CRE_SEARCH_URL = 'http://cre.jp/search/?sw=%s'
+        # %s が与えられたキーワードを URL エンコードした物に置換される
+        CRE_SEARCH_URL = 'https://log.irc.cre.jp/keywords/%s'
 
         # 新しい Keyword::Generator インスタンスを返す
         def initialize

--- a/lib/rgrb/plugin/keyword/generator.rb
+++ b/lib/rgrb/plugin/keyword/generator.rb
@@ -12,7 +12,7 @@ module RGRB
         include PluginBase::Generator
 
         # cre.jp 検索ページの URL
-        # %s が与えられたキーワードを URL エンコードした物に置換される
+        # %s には、URL エンコードされたキーワードが入る
         CRE_SEARCH_URL = 'https://log.irc.cre.jp/keywords/%s'
 
         # 新しい Keyword::Generator インスタンスを返す

--- a/spec/rgrb/plugin/keyword/generator_spec.rb
+++ b/spec/rgrb/plugin/keyword/generator_spec.rb
@@ -11,7 +11,7 @@ describe RGRB::Plugin::Keyword::Generator do
   end
 
   describe '#cre_search' do
-    let(:base_url) { 'http://cre.jp/search/?sw=' }
+    let(:base_url) { 'https://log.irc.cre.jp/keywords/' }
 
     shared_examples 'a Cre search' do
       let(:expected_message) do


### PR DESCRIPTION
ハードコートされている CRE サーチへのURLを、ログアーカイブのキーワード検索ページへの URL に変更しました。
そもそもハードコートではなく、設定ファイルで変更できるようにした方が便利でしょうか？