### PR TITLE
UrlFetchTitle: タイムアウト指定の引数を修正する

### DIFF
--- a/lib/rgrb/plugin/url_fetch_title/generator.rb
+++ b/lib/rgrb/plugin/url_fetch_title/generator.rb
@@ -64,8 +64,7 @@ module RGRB
           body =
             begin
               response = HTTP.
-                timeout(:global,
-                        write: @write_timeout,
+                timeout(write: @write_timeout,
                         connect: @connect_timeout,
                         read: @read_timeout).
                 get(url,


### PR DESCRIPTION
Fixes #190 

Gem http v4のインターフェースに合わせて、HTTP.timeoutを操作別に指定するときは、第1引数にHashを指定するようにします。