### PR TITLE
Ruby 3に対応させる

### DIFF
--- a/lib/rgrb/plugin/online_session_search/generator.rb
+++ b/lib/rgrb/plugin/online_session_search/generator.rb
@@ -37,7 +37,7 @@ module RGRB
         private
 
         def session_data_from(url)
-          json = open(url, 'r:UTF-8') { |f| f.read }
+          json = OpenURI.open_uri(url, 'r:UTF-8') { |f| f.read }
           sessions = Session.parse_json(json)
           format(sessions)
         end


### PR DESCRIPTION
Ruby 3では、OnlineSessionSearchのみで問題が起こっていました。Ruby 3からopen-uriライブラリで `Kernel.#open` が使えなくなったため、`OpenURI.#open_uri` を使うようにして解消できました。