### PR TITLE
ライブラリの更新(202102)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,13 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    ast (2.4.1)
-    bcdice (3.0.0.pre.rc.2)
+    ast (2.4.2)
+    bcdice (3.0.0)
       i18n (~> 1.8.5)
     buftok (0.2.0)
     charlock_holmes (0.7.7)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     crack (0.4.5)
       rexml
     d1lcs (0.5.5)
@@ -28,7 +28,7 @@ GEM
       websocket-client-simple (>= 0.3.0)
     discordrb-webhooks (3.3.0)
       rest-client (>= 2.1.0.rc1)
-    docile (1.3.4)
+    docile (1.3.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
@@ -113,7 +113,7 @@ GEM
       rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.4.0)
+    rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
     simple_oauth (0.3.1)
@@ -142,7 +142,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    webmock (3.11.0)
+    webmock (3.11.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -181,4 +181,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   2.2.4
+   2.2.7


### PR DESCRIPTION
BCDice 3.x 正式版を含む