### PR TITLE
GitHub Actions: libgdbm6をインストールする

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update -qy
-          sudo apt install libgdbm5 libgdbm-dev
+          sudo apt install libgdbm6 libgdbm-dev
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update -qy
-          sudo apt install libgdbm5 libgdbm-dev
+          sudo apt install libgdbm6 libgdbm-dev
       - uses: actions/checkout@v2
         with:
           submodules: recursive


### PR DESCRIPTION
Ubuntu 20.04に更新されてlibgdbm5が使えなくなったため。