### PR TITLE
ライブラリの更新 (202112)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.5
           - 2.6
+          - 2.7
           - 3.0
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    bcdice (3.4.0)
+    bcdice (3.5.0)
       i18n (~> 1.8.5)
     buftok (0.2.0)
     charlock_holmes (0.7.7)
@@ -52,7 +52,7 @@ GEM
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
     lumberjack (1.2.8)
@@ -62,9 +62,9 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
+    mime-types-data (3.2021.1115)
     mini_mime (1.1.2)
     minitest (5.14.4)
     multipart-post (2.1.1)
@@ -75,7 +75,7 @@ GEM
     opus-ruby (1.0.1)
       ffi
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -103,7 +103,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+    rspec-support (3.10.3)
     rubocop (0.93.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -113,7 +113,7 @@ GEM
       rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.12.0)
+    rubocop-ast (1.14.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     simple_oauth (0.3.1)
@@ -146,11 +146,13 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.7.0)
     websocket (1.2.9)
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
-    yard (0.9.26)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -181,4 +183,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   2.2.29
+   2.2.32


### PR DESCRIPTION
サポートが切れ、bcdice 3.5.0 が対応していない ruby 2.5 系列でのテストを廃止した。