### PR TITLE
ライブラリの更新 (202412)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.1'
           - '3.2'
           - '3.3'
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activesupport', '~> 7.0'
+gem 'activesupport', '~> 8.0'
 gem 'lumberjack', '~> 1.0'
 gem 'sysexits', '~> 1.2'
 gem 'http', '> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2)
+    activesupport (8.0.0)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -13,6 +13,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -30,7 +31,7 @@ GEM
       bigdecimal
       rexml
     d1lcs (0.5.5)
-    date (3.4.0)
+    date (3.4.1)
     diff-lcs (1.5.1)
     discordrb (3.5.0)
       discordrb-webhooks (~> 3.5.0)
@@ -68,7 +69,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    logger (1.6.1)
+    logger (1.6.2)
     lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
@@ -104,13 +105,14 @@ GEM
     pry (0.15.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (5.2.0)
+    psych (5.2.1)
+      date
       stringio
     public_suffix (6.0.1)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.2)
+    regexp_parser (2.9.3)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -143,7 +145,7 @@ GEM
     rubocop-ast (1.36.2)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    securerandom (0.3.2)
+    securerandom (0.4.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -158,6 +160,7 @@ GEM
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.2)
     webmock (3.24.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -172,7 +175,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (~> 7.0)
+  activesupport (~> 8.0)
   bcdice
   charlock_holmes (~> 0.7)
   d1lcs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RGRB は Ruby で実装されている汎用 IRC/Discord ボットです。プ�
 
 * Linux または OSX
     * 現在のところ Windows には未対応。
-* Ruby 3.0 以降
+* Ruby 3.2 以降
 
 インストール
 ------------


### PR DESCRIPTION
activesupport を 8.x 系列へ更新を含む。
これにより、Ruby 3.1 未満のサポートを終了する。